### PR TITLE
Validate practice session durations are finite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/gepa_mindfulness/__init__.py
+++ b/gepa_mindfulness/__init__.py
@@ -1,5 +1,10 @@
 """Utility helpers for GEPA mindfulness alignment modeling."""
 
-from .metrics import PracticeSession, aggregate_gepa_score
+from .metrics import AggregateResult, PracticeSession, aggregate_gepa_metrics, aggregate_gepa_score
 
-__all__ = ["PracticeSession", "aggregate_gepa_score"]
+__all__ = [
+    "PracticeSession",
+    "AggregateResult",
+    "aggregate_gepa_metrics",
+    "aggregate_gepa_score",
+]

--- a/gepa_mindfulness/__init__.py
+++ b/gepa_mindfulness/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for GEPA mindfulness alignment modeling."""
+
+from .metrics import PracticeSession, aggregate_gepa_score
+
+__all__ = ["PracticeSession", "aggregate_gepa_score"]

--- a/gepa_mindfulness/metrics.py
+++ b/gepa_mindfulness/metrics.py
@@ -16,7 +16,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import isfinite
+from numbers import Real
 from typing import Iterable
+
+
+def _ensure_real_number(label: str, value: float) -> None:
+    """Raise ``TypeError`` when *value* is not a real number."""
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{label} must be a real number")
 
 
 @dataclass(frozen=True)
@@ -46,6 +54,7 @@ class PracticeSession:
     def validate(self) -> None:
         """Ensure the session data lives within the supported domain."""
 
+        _ensure_real_number("duration_minutes", self.duration_minutes)
         if self.duration_minutes < 0:
             raise ValueError("duration_minutes must be non-negative")
 
@@ -58,6 +67,7 @@ class PracticeSession:
             ("purpose", self.purpose),
             ("awareness", self.awareness),
         ):
+            _ensure_real_number(label, value)
             if not 0.0 <= value <= 1.0:
                 raise ValueError(f"{label} must be within [0.0, 1.0]")
 

--- a/gepa_mindfulness/metrics.py
+++ b/gepa_mindfulness/metrics.py
@@ -69,6 +69,8 @@ class PracticeSession:
             ("awareness", self.awareness),
         ):
             _ensure_real_number(label, value)
+            if not isfinite(float(value)):
+                raise ValueError(f"{label} must be finite")
             if not 0.0 <= value <= 1.0:
                 raise ValueError(f"{label} must be within [0.0, 1.0]")
 

--- a/gepa_mindfulness/metrics.py
+++ b/gepa_mindfulness/metrics.py
@@ -1,0 +1,106 @@
+"""Scoring helpers for GEPA mindfulness sessions.
+
+The module provides a :class:`PracticeSession` data class that represents a
+single training session alongside :func:`aggregate_gepa_score` that aggregates
+several sessions into a single scalar reward.
+
+A bug previously caused :func:`aggregate_gepa_score` to raise ``ZeroDivisionError``
+when all sessions had a duration of zero minutes.  This can easily happen in
+practice when users record preparatory notes without starting the actual timer.
+The fix guards against this situation by returning ``0.0`` for the aggregate
+score whenever there is no time information to average over.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class PracticeSession:
+    """Container describing a mindfulness practice session.
+
+    Attributes
+    ----------
+    duration_minutes:
+        Length of the practice session.  Must be non-negative.
+    grounding:
+        Score in ``[0, 1]`` capturing how grounded the practitioner felt.
+    equanimity:
+        Score in ``[0, 1]`` capturing the level of equanimity.
+    purpose:
+        Score in ``[0, 1]`` capturing clarity of purpose or intention.
+    awareness:
+        Score in ``[0, 1]`` capturing mindfulness awareness.
+    """
+
+    duration_minutes: float
+    grounding: float
+    equanimity: float
+    purpose: float
+    awareness: float
+
+    def validate(self) -> None:
+        """Ensure the session data lives within the supported domain."""
+
+        if self.duration_minutes < 0:
+            raise ValueError("duration_minutes must be non-negative")
+
+        if not isfinite(self.duration_minutes):
+            raise ValueError("duration_minutes must be finite")
+
+        for label, value in (
+            ("grounding", self.grounding),
+            ("equanimity", self.equanimity),
+            ("purpose", self.purpose),
+            ("awareness", self.awareness),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{label} must be within [0.0, 1.0]")
+
+
+def aggregate_gepa_score(sessions: Iterable[PracticeSession]) -> float:
+    """Compute a weighted aggregate GEPA score for several sessions.
+
+    The function averages the per-session GEPA scores weighted by their duration.
+    The score per session is a simple arithmetic mean over the four GEPA axes.
+
+    Parameters
+    ----------
+    sessions:
+        Iterable of :class:`PracticeSession` objects.
+
+    Returns
+    -------
+    float
+        Weighted average GEPA score.  Returns ``0.0`` if all sessions are zero
+        length which avoids the previously existing division-by-zero bug.
+    """
+
+    total_duration = 0.0
+    weighted_sum = 0.0
+
+    for session in sessions:
+        session.validate()
+
+        if session.duration_minutes == 0:
+            # Zero-duration sessions provide qualitative signal without affecting
+            # the quantitative average.  They are ignored but still validated.
+            continue
+
+        gepa_value = (
+            session.grounding
+            + session.equanimity
+            + session.purpose
+            + session.awareness
+        ) / 4.0
+
+        total_duration += session.duration_minutes
+        weighted_sum += gepa_value * session.duration_minutes
+
+    if total_duration == 0:
+        return 0.0
+
+    return weighted_sum / total_duration

--- a/gepa_mindfulness/metrics.py
+++ b/gepa_mindfulness/metrics.py
@@ -15,6 +15,7 @@ there is no time information to average over.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from math import isfinite
 from numbers import Real
 from typing import Iterable
@@ -23,7 +24,7 @@ from typing import Iterable
 def _ensure_real_number(label: str, value: float) -> None:
     """Raise ``TypeError`` when *value* is not a real number."""
 
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if isinstance(value, bool) or not isinstance(value, (Real, Decimal)):
         raise TypeError(f"{label} must be a real number")
 
 
@@ -122,17 +123,18 @@ def aggregate_gepa_metrics(sessions: Iterable[PracticeSession]) -> AggregateResu
     for session in sessions:
         session.validate()
 
-        if session.duration_minutes == 0:
+        weight = float(session.duration_minutes)
+
+        if weight == 0.0:
             # Zero-duration sessions provide qualitative signal without affecting
             # the quantitative average.  They are ignored but still validated.
             continue
 
-        weight = session.duration_minutes
         total_duration += weight
-        grounding_total += session.grounding * weight
-        equanimity_total += session.equanimity * weight
-        purpose_total += session.purpose * weight
-        awareness_total += session.awareness * weight
+        grounding_total += float(session.grounding) * weight
+        equanimity_total += float(session.equanimity) * weight
+        purpose_total += float(session.purpose) * weight
+        awareness_total += float(session.awareness) * weight
 
     if total_duration == 0:
         return AggregateResult(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is importable when running tests without installation.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,67 @@
+import math
+
+import pytest
+
+from gepa_mindfulness import PracticeSession, aggregate_gepa_score
+
+
+def test_aggregate_gepa_score_basic_weighting():
+    sessions = [
+        PracticeSession(duration_minutes=30, grounding=0.6, equanimity=0.5, purpose=0.8, awareness=0.7),
+        PracticeSession(duration_minutes=15, grounding=0.9, equanimity=0.8, purpose=0.9, awareness=0.85),
+    ]
+
+    # expected value computed manually
+    expected = (
+        ((0.6 + 0.5 + 0.8 + 0.7) / 4.0) * 30
+        + ((0.9 + 0.8 + 0.9 + 0.85) / 4.0) * 15
+    ) / 45
+
+    assert math.isclose(aggregate_gepa_score(sessions), expected)
+
+
+def test_zero_duration_sessions_are_ignored():
+    sessions = [
+        PracticeSession(duration_minutes=0, grounding=0.4, equanimity=0.5, purpose=0.6, awareness=0.7),
+        PracticeSession(duration_minutes=0, grounding=0.9, equanimity=0.9, purpose=0.9, awareness=0.9),
+    ]
+
+    assert aggregate_gepa_score(sessions) == 0.0
+
+
+def test_validation_rejects_out_of_range_scores():
+    session = PracticeSession(duration_minutes=10, grounding=1.5, equanimity=0.5, purpose=0.5, awareness=0.5)
+
+    with pytest.raises(ValueError):
+        aggregate_gepa_score([session])
+
+
+def test_validation_rejects_negative_duration():
+    session = PracticeSession(duration_minutes=-1, grounding=0.5, equanimity=0.5, purpose=0.5, awareness=0.5)
+
+    with pytest.raises(ValueError):
+        aggregate_gepa_score([session])
+
+
+def test_validation_rejects_non_finite_duration():
+    session = PracticeSession(
+        duration_minutes=float("nan"),
+        grounding=0.5,
+        equanimity=0.5,
+        purpose=0.5,
+        awareness=0.5,
+    )
+
+    with pytest.raises(ValueError):
+        aggregate_gepa_score([session])
+
+    session = PracticeSession(
+        duration_minutes=float("inf"),
+        grounding=0.5,
+        equanimity=0.5,
+        purpose=0.5,
+        awareness=0.5,
+    )
+
+    with pytest.raises(ValueError):
+        aggregate_gepa_score([session])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -102,3 +102,44 @@ def test_validation_rejects_non_finite_duration():
 
     with pytest.raises(ValueError):
         aggregate_gepa_score([session])
+
+
+def test_validation_rejects_non_numeric_inputs():
+    with pytest.raises(TypeError, match="duration_minutes must be a real number"):
+        aggregate_gepa_score(
+            [
+                PracticeSession(
+                    duration_minutes="ten",
+                    grounding=0.5,
+                    equanimity=0.5,
+                    purpose=0.5,
+                    awareness=0.5,
+                )
+            ]
+        )
+
+    with pytest.raises(TypeError, match="grounding must be a real number"):
+        aggregate_gepa_score(
+            [
+                PracticeSession(
+                    duration_minutes=10,
+                    grounding=None,
+                    equanimity=0.5,
+                    purpose=0.5,
+                    awareness=0.5,
+                )
+            ]
+        )
+
+    with pytest.raises(TypeError, match="awareness must be a real number"):
+        aggregate_gepa_score(
+            [
+                PracticeSession(
+                    duration_minutes=10,
+                    grounding=0.5,
+                    equanimity=0.5,
+                    purpose=0.5,
+                    awareness=True,
+                )
+            ]
+        )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -107,6 +107,30 @@ def test_validation_rejects_non_finite_duration():
         aggregate_gepa_score([session])
 
 
+def test_validation_rejects_non_finite_axis_scores():
+    session = PracticeSession(
+        duration_minutes=10,
+        grounding=Decimal("NaN"),
+        equanimity=0.5,
+        purpose=0.5,
+        awareness=0.5,
+    )
+
+    with pytest.raises(ValueError, match="grounding must be finite"):
+        aggregate_gepa_score([session])
+
+    session = PracticeSession(
+        duration_minutes=10,
+        grounding=0.5,
+        equanimity=float("inf"),
+        purpose=0.5,
+        awareness=0.5,
+    )
+
+    with pytest.raises(ValueError, match="equanimity must be finite"):
+        aggregate_gepa_score([session])
+
+
 def test_validation_rejects_non_numeric_inputs():
     with pytest.raises(TypeError, match="duration_minutes must be a real number"):
         aggregate_gepa_score(


### PR DESCRIPTION
## Summary
- guard practice sessions against NaN or infinite durations before aggregation
- expand unit tests to cover validation of non-finite duration inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d589e418f48330a748743f45e6f7d8