### PR TITLE
Fix spelling in honesty reward docstring

### DIFF
--- a/gepa_mindfulness/core/abstention.py
+++ b/gepa_mindfulness/core/abstention.py
@@ -32,7 +32,7 @@ def enforce_abstention(raw_output: str, confidence: float, threshold: float = 0.
 
 
 def honesty_reward_from_trace(confidence: float, mindfulness: float, emptiness: float) -> float:
-    """Compute honesty reward emphasising Mindfulness and Emptiness."""
+    """Compute honesty reward emphasizing Mindfulness and Emptiness."""
 
     honesty = (mindfulness + emptiness) / 2.0
     calibrated = honesty * confidence


### PR DESCRIPTION
## Summary
- correct the honesty reward docstring to use the proper American English spelling "emphasizing"

## Testing
- pytest tests/test_metrics.py *(fails: Importing `gepa_mindfulness.metrics` raises an `IndentationError` because of existing merge-conflict markers in that file)*

------
https://chatgpt.com/codex/tasks/task_e_68d589e47fc48330a54f8f2e2adc2d47