### PR TITLE
Add distributed training hooks and long-context tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ The offline viewer bundles traces, tokens, and deception metadata into a single
 HTML file that can be opened locally without external dependencies:
 
 ```bash
-gepa view --trace runs/trace.jsonl --tokens runs/tokens.jsonl --out report_view.html
+gepa view --trace runs/trace.jsonl --tokens runs/tokens.jsonl \
+         --out report_view.html --page-size 200 --max-points 5000
 ```
 
 The viewer assets are located in `src/mindful_trace_gepa/viewer/` and are served
@@ -137,6 +138,14 @@ minutes. Launch either notebook to reproduce the LoRA workflow:
 ```bash
 jupyter notebook notebooks/ft_phi3_mini_unsloth_gepa.ipynb
 jupyter notebook notebooks/ft_llama3_8b_unsloth_gepa.ipynb
+```
+
+To launch the notebooks or PPO trainer across multiple GPUs:
+
+```bash
+accelerate launch notebooks/ft_phi3_mini_unsloth_gepa.ipynb
+accelerate launch notebooks/ft_llama3_8b_unsloth_gepa.ipynb
+deepspeed --num_gpus=8 trainer/ppo_gepa.py --config configs/ppo/ppo_default.yaml
 ```
 
 Each run writes `runs/tokens.jsonl`, `runs/trace.jsonl`, `runs/summary.json`,

--- a/configs/deepspeed/ds_zero2.yaml
+++ b/configs/deepspeed/ds_zero2.yaml
@@ -1,0 +1,13 @@
+zero_optimization:
+  stage: 2
+  contiguous_gradients: true
+  overlap_comm: true
+  reduce_scatter: true
+  reduce_bucket_size: 5e7
+  allgather_bucket_size: 5e7
+bf16:
+  enabled: true
+gradient_accumulation_steps: 16
+train_micro_batch_size_per_gpu: 1
+steps_per_print: 100
+wall_clock_breakdown: false

--- a/configs/deepspeed/ds_zero3.yaml
+++ b/configs/deepspeed/ds_zero3.yaml
@@ -1,0 +1,10 @@
+zero_optimization:
+  stage: 3
+  offload_param:
+    device: none
+  offload_optimizer:
+    device: none
+bf16:
+  enabled: true
+gradient_accumulation_steps: 32
+train_micro_batch_size_per_gpu: 1

--- a/configs/models/llama3_8b_lora.yaml
+++ b/configs/models/llama3_8b_lora.yaml
@@ -33,3 +33,13 @@ gepa:
 hardware:
   compile_model: false
   bf16: true
+
+context:
+  max_input_tokens: 32768
+  sliding_window: 8192
+  rope_scaling:
+    type: "linear"
+    factor: 4.0
+
+attention:
+  flash: true

--- a/configs/models/phi3_mini_lora.yaml
+++ b/configs/models/phi3_mini_lora.yaml
@@ -33,3 +33,13 @@ gepa:
 hardware:
   compile_model: false
   bf16: true
+
+context:
+  max_input_tokens: 16384
+  sliding_window: 4096
+  rope_scaling:
+    type: "dynamic"
+    factor: 2.0
+
+attention:
+  flash: true

--- a/configs/train/common.yaml
+++ b/configs/train/common.yaml
@@ -1,0 +1,8 @@
+distributed:
+  backend: "accelerate"
+  mixed_precision: "bf16"
+  gradient_accumulation_steps: 16
+  gradient_checkpointing: true
+  deepspeed_config: "configs/deepspeed/ds_zero2.yaml"
+  zero3_offload: false
+  find_unused_parameters: false

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -1,0 +1,74 @@
+# Distributed Training with Mindful Trace GEPA
+
+This guide explains how to scale GEPA fine-tuning beyond a single GPU while keeping the default
+configuration safe for CPU-based continuous integration jobs.
+
+## Accelerate integration
+
+1. Install the optional dependencies:
+
+   ```bash
+   pip install "accelerate>=0.30" deepspeed
+   ```
+
+2. Configure Accelerate once per machine:
+
+   ```bash
+   accelerate config
+   ```
+
+3. Launch any notebook or Python script that relies on GEPA training helpers via `accelerate launch`:
+
+   ```bash
+   accelerate launch notebooks/ft_llama3_8b_unsloth_gepa.ipynb
+   accelerate launch notebooks/ft_phi3_mini_unsloth_gepa.ipynb
+   ```
+
+   The helper `mindful_trace_gepa.train.dist.get_accelerator` reads
+   `configs/train/common.yaml` and automatically enables mixed precision,
+   gradient accumulation, and gradient checkpointing. If the Accelerate library
+   is not installed the utilities gracefully fall back to a single-process
+   no-op accelerator so CPU smoke tests keep working.
+
+## DeepSpeed launch
+
+DeepSpeed is available by selecting the `deepspeed` backend in the config and
+launching via the DeepSpeed CLI:
+
+```bash
+deepspeed --num_gpus=8 trainer/ppo_gepa.py --config configs/ppo/ppo_default.yaml
+```
+
+The default configuration uses Zero-2 with BF16 (see
+`configs/deepspeed/ds_zero2.yaml`). For larger models use
+`configs/deepspeed/ds_zero3.yaml` and set `distributed.zero3_offload: true` to
+page parameters to CPU memory when necessary.
+
+### Configuration reference
+
+`configs/train/common.yaml` exposes the following knobs:
+
+- `backend`: `"accelerate"` (default) or `"deepspeed"`.
+- `mixed_precision`: `"bf16"`, `"fp16"`, or `"no"`.
+- `gradient_accumulation_steps`: number of micro batches to accumulate.
+- `gradient_checkpointing`: enable checkpointing for long contexts.
+- `deepspeed_config`: path to a DeepSpeed JSON/YAML config file.
+- `zero3_offload`: set to true to offload optimizer/parameters when using
+  Zero-3.
+- `find_unused_parameters`: forwarded to DistributedDataParallel when
+  necessary.
+
+### Saving adapters
+
+Use `mindful_trace_gepa.train.dist.save_sharded` to persist LoRA/QLoRA adapters
+only once from rank 0. The helper enforces synchronization barriers and avoids
+partial checkpoints when multiple processes finish at different times.
+
+### Troubleshooting
+
+- **Accelerate not installed** – the trainer will log a warning and use the
+  `NoOpAccelerator`, ensuring local development still works.
+- **DeepSpeed config missing** – the helpers fall back to the default
+  Accelerate path and emit a warning.
+- **OOM errors** – lower `train_micro_batch_size_per_gpu` in the DeepSpeed
+  config or increase `gradient_accumulation_steps` in `common.yaml`.

--- a/docs/long_context.md
+++ b/docs/long_context.md
@@ -1,0 +1,93 @@
+# Long-Context Training and Analysis
+
+Mindful Trace GEPA now supports traces that exceed 32k tokens by streaming
+storage, configurable context windows, and paginated viewing tools.
+
+## Configuring models for long context
+
+Model presets expose new keys that surface rope scaling and attention
+strategies. Example (`configs/models/llama3_8b_lora.yaml`):
+
+```yaml
+context:
+  max_input_tokens: 32768
+  sliding_window: 8192
+  rope_scaling:
+    type: "linear"
+    factor: 4.0
+attention:
+  flash: true
+```
+
+At runtime, check that the base model supports the requested rope scaling mode.
+If the underlying Hugging Face model rejects the setting the trainer will log a
+warning and fall back to the default context limit.
+
+## Streaming traces and sharding
+
+`TraceArchiveWriter` automatically mirrors the primary `trace.jsonl` while
+splitting large runs into `runs/shards/trace_00001.jsonl` chunks. A manifest
+file (`runs/manifest.json`) records shard paths, counts, and SHA-256 checksums.
+Long traces can be scored in streaming mode via:
+
+```bash
+gepa score --trace runs/trace.jsonl --out report.html --stream --sharded
+```
+
+Pass `--manifest runs/manifest.json` if the manifest lives in a different
+location. Zstandard-compressed shards are detected by extension and will emit a
+hint if the viewer cannot decode them in-browser.
+
+## Token logging controls
+
+Token logs now capture sampled log probabilities and rolling perplexity to keep
+files manageable:
+
+- `--with-logprobs/--no-with-logprobs`
+- `--log-topk 3`
+- `--log-every 16`
+
+These options are available on `gepa dspy run` and reusable from training
+notebooks. Tokens include chunk offsets, making it easy to cross-reference long
+outputs during debugging.
+
+## Offline viewer
+
+The offline viewer supports:
+
+- Pagination (`--page-size`) to limit memory usage.
+- Lazy shard loading using the manifest metadata.
+- Optional down-sampling of token confidence lines via `--max-points`.
+
+Launch with:
+
+```bash
+gepa view --trace runs/trace.jsonl --tokens runs/tokens.jsonl \
+         --out report_view.html --page-size 200 --max-points 5000
+```
+
+If tokens are missing or shards cannot be fetched the viewer surfaces a banner
+rather than crashing.
+
+## Retrieval and slicing
+
+Use `mindful_trace_gepa.utils.longctx.select_top_spans` to retrieve the most
+relevant trace spans before feeding them into a long-context model. The helper
+supports BM25 scoring out of the box and cosine similarity when embeddings are
+provided.
+
+Example:
+
+```python
+from mindful_trace_gepa.utils.longctx import select_top_spans
+
+spans = [
+    {"text": "System review of safety incidents."},
+    {"text": "Detailed financial audit"},
+]
+
+best = select_top_spans("safety incidents with mitigations", spans, k=1)
+```
+
+Combine retrieval with streaming scoring to build RAG-style pipelines that stay
+within the effective context window of each model.

--- a/src/mindful_trace_gepa/cli.py
+++ b/src/mindful_trace_gepa/cli.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import argparse
 import json
+from argparse import BooleanOptionalAction
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional
 
 try:  # pragma: no cover - optional dependency
     import yaml  # type: ignore
@@ -18,17 +19,11 @@ from .tokens import TokenRecorder
 from .viewer.builder import build_viewer_html
 from .emitters.paired_chains import emit_paired
 from .deception.score import score_deception
+from .storage import TraceArchiveWriter, iter_jsonl, load_jsonl, read_jsonl
 
 
 def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
-    data: List[Dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line in handle:
-            line = line.strip()
-            if not line:
-                continue
-            data.append(json.loads(line))
-    return data
+    return read_jsonl(path)
 
 
 def _write_jsonl(path: Path, rows: Iterable[Dict[str, Any]]) -> None:
@@ -52,41 +47,57 @@ def handle_dspy_run(args: argparse.Namespace) -> None:
     summary_path = trace_path.with_name("summary.json")
     deception_path = trace_path.with_name("deception.json")
 
-    trace_rows: List[Dict[str, Any]] = []
-    tokens = TokenRecorder()
+    with_logprobs = getattr(args, "with_logprobs", True)
+    log_topk = getattr(args, "log_topk", 3)
+    log_every = getattr(args, "log_every", 16)
+    long_context = getattr(args, "long_context", False)
+    shard_threshold = max(getattr(args, "shard_threshold", 10_000) or 10_000, 1)
+
+    tokens = TokenRecorder(
+        log_topk=log_topk if with_logprobs else 0,
+        sample_every=log_every if with_logprobs else max(log_every, 1),
+    )
     deception_rows: List[Dict[str, Any]] = []
 
-    for record in input_records:
-        inquiry = record.get("inquiry") or record.get("prompt")
-        if not inquiry:
-            raise ValueError("Each input row must contain an 'inquiry' or 'prompt' field.")
-        context = record.get("context") or args.context or ""
-        result = chain.run(inquiry=inquiry, context=context)
-        abstained = False
-        before_len = len(tokens.records)
-        tokens.record_text(result.final_answer, abstained=abstained)
-        after_records = tokens.records[before_len:]
-        for checkpoint in result.checkpoints:
-            payload = dict(checkpoint)
-            payload.update(
-                {
-                    "gepa_hits": result.gepa_hits,
-                    "principle_scores": result.principle_scores,
-                    "imperative_scores": result.imperative_scores,
-                    "context": context,
-                    "flags": ["dspy-enabled" if config.enabled else "dspy-disabled"],
-                }
-            )
-            trace_rows.append(payload)
-        deception_payload = {
-            "honest_chain": result.checkpoints,
-            "deceptive_chain": [],
-            "final_public_answer": result.final_answer,
-            "confidence_trace": [rec.conf for rec in after_records],
-        }
-        deception_rows.append(score_deception(deception_payload))
+    manifest_path: Optional[Path] = None
 
-    _write_jsonl(trace_path, trace_rows)
+    writer = TraceArchiveWriter(trace_path, shard_threshold=shard_threshold)
+    try:
+        for record in input_records:
+            inquiry = record.get("inquiry") or record.get("prompt")
+            if not inquiry:
+                raise ValueError("Each input row must contain an 'inquiry' or 'prompt' field.")
+            context = record.get("context") or getattr(args, "context", None) or ""
+            result = chain.run(inquiry=inquiry, context=context)
+            abstained = False
+            before_len = len(tokens.records)
+            tokens.record_text(result.final_answer, abstained=abstained)
+            after_records = tokens.records[before_len:]
+            for checkpoint in result.checkpoints:
+                payload = dict(checkpoint)
+                payload.update(
+                    {
+                        "gepa_hits": result.gepa_hits,
+                        "principle_scores": result.principle_scores,
+                        "imperative_scores": result.imperative_scores,
+                        "context": context,
+                        "flags": [
+                            "dspy-enabled" if config.enabled else "dspy-disabled",
+                            "long-context" if long_context else "short-context",
+                        ],
+                    }
+                )
+                writer.append(payload)
+            deception_payload = {
+                "honest_chain": result.checkpoints,
+                "deceptive_chain": [],
+                "final_public_answer": result.final_answer,
+                "confidence_trace": [rec.conf for rec in after_records],
+            }
+            deception_rows.append(score_deception(deception_payload))
+    finally:
+        manifest_path = writer.close()
+
     tokens.dump_jsonl(tokens_path)
     dump_json(
         summary_path,
@@ -95,6 +106,7 @@ def handle_dspy_run(args: argparse.Namespace) -> None:
             "policy_version": "dspy-chain-v1",
             "thresholds": {"abstention": 0.75},
             "hashes": {"dspy_config": str(load_dspy_config())},
+            "shards": str(manifest_path) if manifest_path else None,
         },
     )
     dump_json(deception_path, {"runs": deception_rows})
@@ -118,9 +130,31 @@ def handle_dspy_compile(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 def handle_view(args: argparse.Namespace) -> None:
-    trace_rows = _read_jsonl(Path(args.trace))
+    trace_path = Path(args.trace)
     token_path = Path(args.tokens)
-    token_rows = _read_jsonl(token_path) if token_path.exists() else []
+    out_path = Path(args.out)
+    page_size = getattr(args, "page_size", 200)
+    max_points = getattr(args, "max_points", 5000)
+
+    trace_rows: List[Dict[str, Any]] = []
+    if trace_path.exists():
+        trace_rows = load_jsonl(trace_path, limit=page_size)
+
+    token_rows: List[Dict[str, Any]] = []
+    if token_path.exists():
+        token_rows = load_jsonl(token_path, limit=max_points)
+
+    manifest_data: Dict[str, Any] = {}
+    manifest_override = getattr(args, "manifest", None)
+    manifest_path = Path(manifest_override) if manifest_override else trace_path.with_name("manifest.json")
+    manifest_rel: Optional[str] = None
+    if manifest_path.exists():
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        try:
+            manifest_rel = str(manifest_path.relative_to(out_path.parent))
+        except ValueError:
+            manifest_rel = str(manifest_path.resolve())
+
     deception_data = {}
     if args.deception and Path(args.deception).exists():
         with Path(args.deception).open("r", encoding="utf-8") as handle:
@@ -133,8 +167,14 @@ def handle_view(args: argparse.Namespace) -> None:
         trace_events=trace_rows,
         token_events=token_rows,
         deception=deception_data,
-        output_path=Path(args.out),
+        output_path=out_path,
         paired=paired_data,
+        manifest=manifest_data,
+        settings={
+            "pageSize": page_size,
+            "maxPoints": max_points,
+            "manifestPath": manifest_rel,
+        },
     )
 
 
@@ -191,7 +231,20 @@ def handle_paired_view(args: argparse.Namespace) -> None:
 
 
 def handle_score(args: argparse.Namespace) -> None:
-    trace_rows = _read_jsonl(Path(args.trace))
+    trace_path = Path(args.trace)
+    zstd_flag = getattr(args, "zstd", False)
+    stream_flag = getattr(args, "stream", True)
+    sharded_flag = getattr(args, "sharded", False)
+    manifest_override = getattr(args, "manifest", None)
+
+    if zstd_flag and not trace_path.exists():
+        candidate = (
+            trace_path.with_suffix(trace_path.suffix + ".zst")
+            if trace_path.suffix
+            else trace_path.with_name(f"{trace_path.name}.zst")
+        )
+        if candidate.exists():
+            trace_path = candidate
     policy = {}
     if args.policy and Path(args.policy).exists():
         policy_path = Path(args.policy)
@@ -201,22 +254,53 @@ def handle_score(args: argparse.Namespace) -> None:
         else:
             policy = {"raw": raw}
 
-    principle_totals: Dict[str, List[float]] = {}
-    imperative_totals: Dict[str, List[float]] = {}
-    for event in trace_rows:
-        for key, value in (event.get("principle_scores") or {}).items():
-            principle_totals.setdefault(key, []).append(float(value))
-        for key, value in (event.get("imperative_scores") or {}).items():
-            imperative_totals.setdefault(key, []).append(float(value))
+    def _iter_events() -> Iterable[Dict[str, Any]]:
+        if sharded_flag:
+            manifest_path = Path(manifest_override) if manifest_override else (
+                trace_path if trace_path.name == "manifest.json" else trace_path.with_name("manifest.json")
+            )
+            if not manifest_path.exists():
+                raise FileNotFoundError(f"Manifest not found at {manifest_path}")
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            base = manifest_path.parent
+            for shard in manifest.get("shards", []):
+                shard_path = base / shard["path"]
+                yield from iter_jsonl(shard_path)
+        else:
+            yield from iter_jsonl(trace_path)
 
-    def _mean(values: List[float]) -> float:
-        return sum(values) / len(values) if values else 0.0
+    event_iter: Iterable[Dict[str, Any]]
+    if stream_flag:
+        event_iter = _iter_events()
+    else:
+        event_iter = list(_iter_events())
+
+    principle_sums: Dict[str, float] = {}
+    principle_counts: Dict[str, int] = {}
+    imperative_sums: Dict[str, float] = {}
+    imperative_counts: Dict[str, int] = {}
+    flags_seen: set[str] = set()
+    total_events = 0
+    for event in event_iter:
+        total_events += 1
+        for key, value in (event.get("principle_scores") or {}).items():
+            principle_sums[key] = principle_sums.get(key, 0.0) + float(value)
+            principle_counts[key] = principle_counts.get(key, 0) + 1
+        for key, value in (event.get("imperative_scores") or {}).items():
+            imperative_sums[key] = imperative_sums.get(key, 0.0) + float(value)
+            imperative_counts[key] = imperative_counts.get(key, 0) + 1
+        for flag in event.get("flags", []) or []:
+            flags_seen.add(flag)
+
+    def _mean(sums: Dict[str, float], counts: Dict[str, int]) -> Dict[str, float]:
+        return {name: (sums[name] / counts[name]) for name in sums}
 
     summary = {
-        "principles": {name: _mean(values) for name, values in principle_totals.items()},
-        "imperatives": {name: _mean(values) for name, values in imperative_totals.items()},
-        "events": len(trace_rows),
+        "principles": _mean(principle_sums, principle_counts),
+        "imperatives": _mean(imperative_sums, imperative_counts),
+        "events": total_events,
         "policy": policy,
+        "flags": sorted(flags_seen),
     }
 
     html_parts = [
@@ -253,6 +337,11 @@ def build_parser() -> argparse.ArgumentParser:
     dspy_run.add_argument("--context", help="Optional profile context")
     dspy_run.add_argument("--model", help="Model identifier")
     dspy_run.add_argument("--enable-optim", action="store_true", help="Opt-in to optimisation features")
+    dspy_run.add_argument("--with-logprobs", action=BooleanOptionalAction, default=True, help="Record log probabilities")
+    dspy_run.add_argument("--log-topk", type=int, default=3, help="Number of top-k alternatives to store")
+    dspy_run.add_argument("--log-every", type=int, default=16, help="Sample frequency for token logging")
+    dspy_run.add_argument("--long-context", action="store_true", help="Enable long-context formatting hints")
+    dspy_run.add_argument("--shard-threshold", type=int, default=10_000, help="Events per shard before splitting")
     dspy_run.set_defaults(func=handle_dspy_run)
 
     dspy_compile = dspy_sub.add_parser("compile", help="Compile guarded DSPy prompts")
@@ -267,6 +356,9 @@ def build_parser() -> argparse.ArgumentParser:
     view_parser.add_argument("--out", required=True, help="Output HTML file")
     view_parser.add_argument("--deception", help="Optional deception score JSON")
     view_parser.add_argument("--paired", help="Optional paired metadata JSON")
+    view_parser.add_argument("--page-size", type=int, default=200, help="Events per page in the viewer")
+    view_parser.add_argument("--max-points", type=int, default=5000, help="Maximum token events to embed inline")
+    view_parser.add_argument("--manifest", help="Optional manifest path (auto-detected if omitted)")
     view_parser.set_defaults(func=handle_view)
 
     paired_parser = subparsers.add_parser("paired", help="Paired honest/deceptive baseline")
@@ -288,6 +380,10 @@ def build_parser() -> argparse.ArgumentParser:
     score_parser.add_argument("--trace", required=True, help="Trace JSONL path")
     score_parser.add_argument("--policy", required=False, help="Policy YAML path")
     score_parser.add_argument("--out", required=True, help="Output HTML report")
+    score_parser.add_argument("--stream", action=BooleanOptionalAction, default=True, help="Stream events during scoring")
+    score_parser.add_argument("--sharded", action="store_true", help="Read trace shards via manifest")
+    score_parser.add_argument("--manifest", help="Optional manifest path for sharded runs")
+    score_parser.add_argument("--zstd", action="store_true", help="Hint: trace files are zstd compressed")
     score_parser.set_defaults(func=handle_score)
 
     return parser

--- a/src/mindful_trace_gepa/storage/__init__.py
+++ b/src/mindful_trace_gepa/storage/__init__.py
@@ -1,0 +1,17 @@
+"""Streaming storage helpers for GEPA traces."""
+
+from .jsonl_store import (
+    ShardedTraceWriter,
+    TraceArchiveWriter,
+    iter_jsonl,
+    load_jsonl,
+    read_jsonl,
+)
+
+__all__ = [
+    "iter_jsonl",
+    "read_jsonl",
+    "load_jsonl",
+    "ShardedTraceWriter",
+    "TraceArchiveWriter",
+]

--- a/src/mindful_trace_gepa/storage/jsonl_store.py
+++ b/src/mindful_trace_gepa/storage/jsonl_store.py
@@ -1,0 +1,251 @@
+"""JSONL storage utilities supporting streaming and sharding."""
+from __future__ import annotations
+
+import io
+import json
+import hashlib
+import logging
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, List, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    import zstandard as zstd  # type: ignore
+except Exception:  # pragma: no cover
+    zstd = None  # type: ignore
+
+
+def _open_text(path: Path) -> io.TextIOBase:
+    if path.suffix == ".zst" or path.name.endswith(".jsonl.zst"):
+        if zstd is None:
+            raise RuntimeError("zstandard is required to read compressed traces")
+        fh = path.open("rb")
+        reader = zstd.ZstdDecompressor().stream_reader(fh)
+        return io.TextIOWrapper(reader, encoding="utf-8")
+    return path.open("r", encoding="utf-8")
+
+
+def iter_jsonl(path: Path | str) -> Iterator[dict[str, Any]]:
+    """Yield JSON rows from the provided file without loading everything into memory."""
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with _open_text(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as exc:  # pragma: no cover - guard rail
+                LOGGER.warning("Skipping malformed JSONL line in %s: %s", path, exc)
+
+
+def load_jsonl(path: Path | str, limit: Optional[int] = None) -> List[dict[str, Any]]:
+    """Load up to ``limit`` rows into memory, streaming from disk."""
+
+    rows: List[dict[str, Any]] = []
+    for idx, row in enumerate(iter_jsonl(path)):
+        if limit is not None and idx >= limit:
+            break
+        rows.append(row)
+    return rows
+
+
+def read_jsonl(path: Path | str) -> List[dict[str, Any]]:
+    """Compatibility helper that loads the entire file."""
+
+    return load_jsonl(path, limit=None)
+
+
+@dataclass
+class ShardInfo:
+    path: str
+    events: int
+    sha256: str
+
+
+class ShardedTraceWriter:
+    """Write trace events to multiple shards with a manifest."""
+
+    def __init__(
+        self,
+        base_dir: Path | str,
+        *,
+        prefix: str = "trace",
+        max_events: int = 10_000,
+        compress: bool = False,
+    ) -> None:
+        self.base_dir = Path(base_dir)
+        self.prefix = prefix
+        self.max_events = max_events
+        self.compress = compress and zstd is not None
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.shard_dir = self.base_dir / "shards"
+        self.shard_dir.mkdir(parents=True, exist_ok=True)
+        self._current_handle: Optional[io.TextIOBase] = None
+        self._current_hash: Optional[hashlib._Hash] = None
+        self._current_context: Optional[AbstractContextManager[io.TextIOBase]] = None
+        self._current_events = 0
+        self._total_events = 0
+        self._shards: List[ShardInfo] = []
+        self._index = 0
+
+    @contextmanager
+    def _open_shard(self) -> Iterator[io.TextIOBase]:
+        self._index += 1
+        suffix = ".jsonl"
+        if self.compress:
+            suffix += ".zst"
+        filename = f"{self.prefix}_{self._index:05d}{suffix}"
+        path = self.shard_dir / filename
+        stream = None
+        if self.compress:
+            assert zstd is not None  # for type checkers
+            compressor = zstd.ZstdCompressor(level=3)
+            fh = path.open("wb")
+            stream = compressor.stream_writer(fh)
+            text_handle = io.TextIOWrapper(stream, encoding="utf-8")
+        else:
+            text_handle = path.open("w", encoding="utf-8")
+        self._current_hash = hashlib.sha256()
+        try:
+            yield text_handle
+        finally:
+            text_handle.flush()
+            text_handle.close()
+            if stream is not None:
+                stream.close()
+            events = self._current_events
+            if events == 0:
+                path.unlink(missing_ok=True)
+            else:
+                sha_hex = self._current_hash.hexdigest() if self._current_hash else ""
+                relative = path.relative_to(self.base_dir)
+                self._shards.append(ShardInfo(path=str(relative), events=events, sha256=sha_hex))
+            self._current_handle = None
+            self._current_hash = None
+            self._current_events = 0
+
+    def _ensure_handle(self) -> io.TextIOBase:
+        if self._current_handle is None:
+            context = self._open_shard()
+            handle = context.__enter__()
+            self._current_handle = handle
+            self._current_context = context
+        return self._current_handle
+
+    def append(self, event: dict[str, Any]) -> None:
+        handle = self._ensure_handle()
+        line = json.dumps(event, ensure_ascii=False)
+        payload = f"{line}\n"
+        handle.write(payload)
+        if self._current_hash is not None:
+            self._current_hash.update(payload.encode("utf-8"))
+        self._current_events += 1
+        self._total_events += 1
+        if self._current_events >= self.max_events:
+            self._close_current()
+
+    def _close_current(self) -> None:
+        if self._current_handle is None:
+            return
+        if self._current_context:
+            self._current_context.__exit__(None, None, None)
+        self._current_handle = None
+        self._current_context = None
+
+    def close(self) -> Path:
+        self._close_current()
+        manifest = {
+            "version": 1,
+            "total_events": self._total_events,
+            "shards": [shard.__dict__ for shard in self._shards],
+        }
+        manifest_path = self.base_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        return manifest_path
+
+    def __enter__(self) -> "ShardedTraceWriter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+class TraceArchiveWriter:
+    """Write a primary JSONL trace and optional shards simultaneously."""
+
+    def __init__(
+        self,
+        trace_path: Path | str,
+        *,
+        shard_threshold: int = 10_000,
+        compress_shards: bool = False,
+    ) -> None:
+        self.trace_path = Path(trace_path)
+        self.trace_path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.trace_path.open("w", encoding="utf-8")
+        self._shard_threshold = shard_threshold
+        self._buffer: List[dict[str, Any]] = []
+        self._sharder: Optional[ShardedTraceWriter] = None
+        self._compress = compress_shards
+        self._closed = False
+        self._manifest_path: Optional[Path] = None
+
+    def _ensure_sharder(self) -> None:
+        if self._sharder is not None:
+            return
+        self._sharder = ShardedTraceWriter(
+            self.trace_path.parent,
+            prefix=self.trace_path.stem,
+            max_events=self._shard_threshold,
+            compress=self._compress,
+        )
+        for row in self._buffer:
+            self._sharder.append(row)
+        self._buffer.clear()
+
+    def append(self, event: dict[str, Any]) -> None:
+        line = json.dumps(event, ensure_ascii=False)
+        self._handle.write(f"{line}\n")
+        if self._sharder is None and len(self._buffer) >= self._shard_threshold:
+            self._ensure_sharder()
+        if self._sharder is not None:
+            self._sharder.append(event)
+        else:
+            self._buffer.append(event)
+
+    def close(self) -> Optional[Path]:
+        if self._closed:
+            return self._manifest_path
+        manifest: Optional[Path] = None
+        if self._sharder is not None:
+            for row in self._buffer:
+                self._sharder.append(row)
+            manifest = self._sharder.close()
+        self._buffer.clear()
+        self._handle.close()
+        self._closed = True
+        self._manifest_path = manifest
+        return manifest
+
+    def __enter__(self) -> "TraceArchiveWriter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = [
+    "iter_jsonl",
+    "load_jsonl",
+    "read_jsonl",
+    "ShardedTraceWriter",
+    "ShardInfo",
+    "TraceArchiveWriter",
+]

--- a/src/mindful_trace_gepa/tokens.py
+++ b/src/mindful_trace_gepa/tokens.py
@@ -24,19 +24,44 @@ class TokenRecord:
     conf: float
     abstained: bool
     ts: str
+    chunk: int
+    offset: int
+    ppl: float | None = None
 
 
 class TokenRecorder:
-    def __init__(self) -> None:
+    def __init__(self, *, log_topk: int = 0, sample_every: int = 1) -> None:
         self.records: List[TokenRecord] = []
+        self.log_topk = max(0, log_topk)
+        self.sample_every = max(1, sample_every)
+        self._global_idx = 0
+        self._rolling_logprob = 0.0
+
+    def _mock_topk(self, token: str, logprob: float) -> Sequence[TokenTopK]:
+        if self.log_topk <= 0:
+            return []
+        decay = 0.5
+        topk: List[TokenTopK] = []
+        for rank in range(self.log_topk):
+            lp = logprob - decay * rank
+            candidate = f"{token}_{rank}" if rank else token
+            topk.append(TokenTopK(t=candidate, lp=lp))
+        return topk
 
     def record_text(self, text: str, abstained: bool = False) -> None:
         tokens = text.split()
         now = datetime.utcnow().isoformat()
-        for idx, token in enumerate(tokens):
-            logprob = -math.log1p(idx + 1)
+        for token in tokens or [""]:
+            logprob = -math.log1p(self._global_idx + 1)
             confidence = max(0.0, 1.0 + logprob / 5.0)
-            topk = [TokenTopK(t=token, lp=logprob)]
+            self._global_idx += 1
+            if (self._global_idx - 1) % self.sample_every != 0:
+                continue
+            chunk = (self._global_idx - 1) // self.sample_every
+            offset = (self._global_idx - 1) % self.sample_every
+            self._rolling_logprob = 0.95 * self._rolling_logprob + 0.05 * logprob
+            perplexity = math.exp(-self._rolling_logprob) if self._rolling_logprob else None
+            topk = self._mock_topk(token, logprob)
             self.records.append(
                 TokenRecord(
                     idx=len(self.records),
@@ -46,18 +71,9 @@ class TokenRecorder:
                     conf=confidence,
                     abstained=abstained,
                     ts=now,
-                )
-            )
-        if not tokens:
-            self.records.append(
-                TokenRecord(
-                    idx=len(self.records),
-                    token="",
-                    logprob=None,
-                    topk=[],
-                    conf=0.0,
-                    abstained=abstained,
-                    ts=now,
+                    chunk=chunk,
+                    offset=offset,
+                    ppl=perplexity,
                 )
             )
 
@@ -65,6 +81,8 @@ class TokenRecorder:
         for record in other:
             record.idx = len(self.records)  # type: ignore[attr-defined]
             self.records.append(record)
+            inferred_global = record.chunk * self.sample_every + record.offset + 1
+            self._global_idx = max(self._global_idx, inferred_global)
 
     def dump_jsonl(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mindful_trace_gepa/train/__init__.py
+++ b/src/mindful_trace_gepa/train/__init__.py
@@ -1,0 +1,5 @@
+"""Training utilities for Mindful Trace GEPA."""
+
+from .dist import get_accelerator, wrap_model_optimizer, save_sharded
+
+__all__ = ["get_accelerator", "wrap_model_optimizer", "save_sharded"]

--- a/src/mindful_trace_gepa/train/dist.py
+++ b/src/mindful_trace_gepa/train/dist.py
@@ -1,0 +1,178 @@
+"""Distributed training helpers integrating Accelerate and DeepSpeed."""
+from __future__ import annotations
+
+import contextlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+import torch
+
+try:  # pragma: no cover - optional dependency
+    from accelerate import Accelerator
+    from accelerate.utils import DeepSpeedPlugin
+except Exception:  # pragma: no cover
+    Accelerator = None  # type: ignore
+    DeepSpeedPlugin = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class DistributedConfig:
+    backend: str = "accelerate"
+    mixed_precision: str = "no"
+    gradient_accumulation_steps: int = 1
+    gradient_checkpointing: bool = False
+    deepspeed_config: Optional[str] = None
+    zero3_offload: bool = False
+    find_unused_parameters: bool = False
+
+    @classmethod
+    def from_mapping(cls, mapping: Optional[dict[str, Any]]) -> "DistributedConfig":
+        if not mapping:
+            return cls()
+        return cls(
+            backend=mapping.get("backend", "accelerate"),
+            mixed_precision=mapping.get("mixed_precision", "no"),
+            gradient_accumulation_steps=int(mapping.get("gradient_accumulation_steps", 1)),
+            gradient_checkpointing=bool(mapping.get("gradient_checkpointing", False)),
+            deepspeed_config=mapping.get("deepspeed_config"),
+            zero3_offload=bool(mapping.get("zero3_offload", False)),
+            find_unused_parameters=bool(mapping.get("find_unused_parameters", False)),
+        )
+
+
+class NoOpAccelerator:
+    """Fallback accelerator used when Accelerate is unavailable."""
+
+    def __init__(self, gradient_accumulation_steps: int = 1) -> None:
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def prepare(self, *objects: Any) -> Tuple[Any, ...]:
+        return objects
+
+    def accumulate(self, _model: torch.nn.Module) -> contextlib.AbstractContextManager[None]:
+        return contextlib.nullcontext()
+
+    def backward(self, loss: torch.Tensor) -> None:
+        loss.backward()
+
+    def wait_for_everyone(self) -> None:  # pragma: no cover - noop
+        return None
+
+    @property
+    def is_main_process(self) -> bool:  # pragma: no cover - compatibility
+        return True
+
+    def unwrap_model(self, model: torch.nn.Module) -> torch.nn.Module:
+        return model
+
+    def print(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - passthrough
+        print(*args, **kwargs)
+
+    def save(self, obj: Any, path: Path) -> None:
+        torch.save(obj, path)
+
+
+def _build_deepspeed_plugin(cfg: DistributedConfig) -> Optional[DeepSpeedPlugin]:
+    if DeepSpeedPlugin is None:
+        LOGGER.warning("DeepSpeed support requested but accelerate is unavailable.")
+        return None
+    if not cfg.deepspeed_config:
+        LOGGER.warning("DeepSpeed backend requested without config file; falling back to accelerate mode.")
+        return None
+    stage3_offload = cfg.zero3_offload
+    return DeepSpeedPlugin(
+        gradient_accumulation_steps=cfg.gradient_accumulation_steps,
+        gradient_clipping=None,
+        zero_stage=3 if stage3_offload else None,
+        offload_optimizer_device="cpu" if stage3_offload else None,
+        offload_param_device="cpu" if stage3_offload else None,
+        deepspeed_config_path=cfg.deepspeed_config,
+    )
+
+
+def get_accelerator(config: Optional[dict[str, Any]] = None) -> Any:
+    """Return an appropriate accelerator instance for the given configuration."""
+
+    cfg = DistributedConfig.from_mapping((config or {}).get("distributed")) if config else DistributedConfig()
+
+    if Accelerator is None:
+        LOGGER.info("accelerate is not installed; using NoOpAccelerator.")
+        return NoOpAccelerator(gradient_accumulation_steps=cfg.gradient_accumulation_steps)
+
+    kwargs: dict[str, Any] = {
+        "mixed_precision": cfg.mixed_precision,
+        "gradient_accumulation_steps": cfg.gradient_accumulation_steps,
+        "log_with": None,
+    }
+
+    if cfg.backend == "deepspeed":
+        plugin = _build_deepspeed_plugin(cfg)
+        if plugin is None:
+            LOGGER.warning("Falling back to Accelerate defaults due to missing DeepSpeed plugin.")
+        else:
+            kwargs["deepspeed_plugin"] = plugin
+            kwargs["dispatch_batches"] = True
+    accelerator = Accelerator(**kwargs)
+    return accelerator
+
+
+def _enable_gradient_checkpointing(model: torch.nn.Module) -> None:
+    if hasattr(model, "gradient_checkpointing_enable"):
+        model.gradient_checkpointing_enable()
+    elif hasattr(model, "enable_gradient_checkpointing"):
+        model.enable_gradient_checkpointing()
+    else:  # pragma: no cover - nothing to do
+        LOGGER.debug("Model does not expose gradient checkpointing hooks.")
+
+
+def wrap_model_optimizer(
+    model: torch.nn.Module,
+    optimizer: Optional[torch.optim.Optimizer],
+    accelerator: Any,
+    *,
+    gradient_checkpointing: Optional[bool] = None,
+) -> Tuple[torch.nn.Module, Optional[torch.optim.Optimizer]]:
+    """Prepare model and optimizer for distributed training."""
+
+    cfg_checkpoint = gradient_checkpointing
+    if cfg_checkpoint is None and hasattr(accelerator, "state"):
+        cfg_checkpoint = getattr(getattr(accelerator, "state", object()), "gradient_checkpointing", None)
+
+    if cfg_checkpoint:
+        _enable_gradient_checkpointing(model)
+
+    if hasattr(accelerator, "prepare"):
+        prepared = accelerator.prepare(*(tuple(obj for obj in (model, optimizer) if obj is not None)))
+        if optimizer is None:
+            return prepared[0] if isinstance(prepared, (list, tuple)) else prepared, None
+        if isinstance(prepared, (list, tuple)) and len(prepared) == 2:
+            return prepared[0], prepared[1]
+        if isinstance(prepared, tuple) and len(prepared) == 1:
+            return prepared[0], optimizer
+        return prepared  # type: ignore[return-value]
+    return model, optimizer
+
+
+def save_sharded(adapter: Any, out_dir: Path | str, accelerator: Any) -> Path:
+    """Save adapter weights once across distributed workers."""
+
+    out_path = Path(out_dir)
+    accelerator.wait_for_everyone()
+    if getattr(accelerator, "is_main_process", True):
+        out_path.mkdir(parents=True, exist_ok=True)
+        if hasattr(adapter, "save_pretrained"):
+            adapter.save_pretrained(out_path)
+        elif hasattr(adapter, "state_dict"):
+            torch.save(adapter.state_dict(), out_path / "adapter.bin")
+        else:
+            raise AttributeError("Adapter does not implement a supported save method.")
+    accelerator.wait_for_everyone()
+    return out_path
+
+
+__all__ = ["get_accelerator", "wrap_model_optimizer", "save_sharded", "DistributedConfig", "NoOpAccelerator"]

--- a/src/mindful_trace_gepa/utils/__init__.py
+++ b/src/mindful_trace_gepa/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for Mindful Trace GEPA."""

--- a/src/mindful_trace_gepa/utils/longctx/__init__.py
+++ b/src/mindful_trace_gepa/utils/longctx/__init__.py
@@ -1,0 +1,5 @@
+"""Long-context utilities."""
+
+from .select_spans import select_top_spans
+
+__all__ = ["select_top_spans"]

--- a/src/mindful_trace_gepa/utils/longctx/select_spans.py
+++ b/src/mindful_trace_gepa/utils/longctx/select_spans.py
@@ -1,0 +1,127 @@
+"""Utilities for selecting long-context spans via lightweight retrieval."""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+
+_TOKEN_RE = re.compile(r"\w+")
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token.lower() for token in _TOKEN_RE.findall(text or "")]
+
+
+@dataclass
+class Span:
+    text: str
+    metadata: dict | None = None
+    embedding: Sequence[float] | None = None
+
+
+def _bm25_score(query_tokens: Sequence[str], doc_tokens: Sequence[str], idf: dict[str, float], avg_len: float) -> float:
+    k1 = 1.5
+    b = 0.75
+    score = 0.0
+    doc_len = len(doc_tokens) or 1
+    tf = {}
+    for token in doc_tokens:
+        tf[token] = tf.get(token, 0) + 1
+    for token in query_tokens:
+        if token not in tf:
+            continue
+        numerator = tf[token] * (k1 + 1)
+        denominator = tf[token] + k1 * (1 - b + b * doc_len / avg_len)
+        score += idf.get(token, 0.0) * (numerator / denominator)
+    return score
+
+
+def _build_idf(corpus: Sequence[Sequence[str]]) -> tuple[dict[str, float], float]:
+    doc_freq: dict[str, int] = {}
+    for tokens in corpus:
+        seen = set(tokens)
+        for token in seen:
+            doc_freq[token] = doc_freq.get(token, 0) + 1
+    total_docs = max(len(corpus), 1)
+    idf = {
+        token: math.log((total_docs - freq + 0.5) / (freq + 0.5) + 1)
+        for token, freq in doc_freq.items()
+    }
+    avg_len = sum(len(tokens) for tokens in corpus) / max(total_docs, 1)
+    return idf, avg_len or 1.0
+
+
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return -1.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return -1.0
+    return dot / (norm_a * norm_b)
+
+
+def select_top_spans(
+    query: str,
+    spans: Iterable[Span | dict | str],
+    *,
+    k: int = 3,
+    method: str = "bm25",
+    query_embedding: Sequence[float] | None = None,
+) -> List[Span]:
+    """Select the top-k spans matching a query.
+
+    Parameters
+    ----------
+    query:
+        The textual query describing desired content.
+    spans:
+        Iterable of ``Span`` objects, dictionaries with a ``text`` field, or plain strings.
+    k:
+        Number of spans to return.
+    method:
+        Retrieval scoring method. ``"bm25"`` (default) or ``"cosine"`` for embedding cosine similarity.
+    query_embedding:
+        Optional embedding vector for the query when using cosine similarity.
+    """
+
+    normalized: List[Span] = []
+    for item in spans:
+        if isinstance(item, Span):
+            normalized.append(item)
+        elif isinstance(item, str):
+            normalized.append(Span(text=item))
+        else:
+            text = str(item.get("text", ""))
+            embedding = item.get("embedding")
+            metadata = {k: v for k, v in item.items() if k not in {"text", "embedding"}}
+            normalized.append(Span(text=text, metadata=metadata or None, embedding=embedding))
+
+    if not normalized:
+        return []
+
+    if method == "cosine":
+        if query_embedding is None:
+            raise ValueError("query_embedding must be provided for cosine similarity retrieval")
+        scored = [
+            (idx, _cosine_similarity(query_embedding, span.embedding or []))
+            for idx, span in enumerate(normalized)
+        ]
+    else:
+        doc_tokens = [_tokenize(span.text) for span in normalized]
+        idf, avg_len = _build_idf(doc_tokens)
+        query_tokens = _tokenize(query)
+        scored = [
+            (idx, _bm25_score(query_tokens, doc_tokens[idx], idf, avg_len))
+            for idx in range(len(normalized))
+        ]
+
+    scored.sort(key=lambda item: item[1], reverse=True)
+    top_spans = [normalized[idx] for idx, score in scored[:k] if score > -1]
+    return top_spans
+
+
+__all__ = ["select_top_spans", "Span"]

--- a/src/mindful_trace_gepa/viewer/builder.py
+++ b/src/mindful_trace_gepa/viewer/builder.py
@@ -21,7 +21,8 @@ def build_viewer_html(
     output_path: Path,
     deception: Dict[str, Any] | None = None,
     paired: Dict[str, Any] | None = None,
-    extra: Dict[str, Any] | None = None,
+    manifest: Dict[str, Any] | None = None,
+    settings: Dict[str, Any] | None = None,
 ) -> Path:
     html = load_static_asset("viewer.html")
     script = load_static_asset("viewer.js")
@@ -32,7 +33,8 @@ def build_viewer_html(
         "tokens": token_events,
         "deception": deception or {},
         "paired": paired or {},
-        "extra": extra or {},
+        "manifest": manifest or {},
+        "settings": settings or {},
     }
     data_blob = json.dumps(payload)
 

--- a/src/mindful_trace_gepa/viewer/viewer.css
+++ b/src/mindful_trace_gepa/viewer/viewer.css
@@ -29,6 +29,16 @@ main {
   padding: 1.5rem;
 }
 
+.banner {
+  margin: 0.5rem 1.5rem 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.9rem;
+  display: none;
+}
+
 .panel {
   background: #fff;
   border-radius: 0.75rem;
@@ -45,6 +55,34 @@ main {
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+#timeline-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+#timeline-controls button {
+  background: #1f3c88;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+#timeline-controls button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+#timeline-controls .page-info {
+  font-size: 0.85rem;
+  color: #475569;
 }
 
 #timeline-list li {

--- a/src/mindful_trace_gepa/viewer/viewer.html
+++ b/src/mindful_trace_gepa/viewer/viewer.html
@@ -12,9 +12,11 @@
       <h1>Mindful Trace GEPA Viewer</h1>
       <p class="subtitle">Offline trace inspection with honesty and deception baselines.</p>
     </header>
+    <div id="info-banner" class="banner"></div>
     <main>
       <section id="timeline" class="panel">
         <h2>Timeline</h2>
+        <div id="timeline-controls" class="controls"></div>
         <ul id="timeline-list"></ul>
       </section>
       <section id="event" class="panel">

--- a/src/mindful_trace_gepa/viewer/viewer.js
+++ b/src/mindful_trace_gepa/viewer/viewer.js
@@ -1,36 +1,204 @@
 (function () {
   const data = window.__GEPA__ || {};
-  const events = data.trace || [];
+  const manifest = data.manifest || {};
+  const settings = data.settings || {};
+  const pageSize = Math.max(1, settings.pageSize || 200);
+  const maxPoints = Math.max(1, settings.maxPoints || 5000);
+  const manifestPath = settings.manifestPath || null;
+
   const tokens = data.tokens || [];
   const deception = data.deception || {};
   const paired = data.paired || {};
 
   const timelineList = document.getElementById("timeline-list");
+  const controls = document.getElementById("timeline-controls");
+  const infoBanner = document.getElementById("info-banner");
   const eventText = document.getElementById("event-text");
   const eventMeta = document.getElementById("event-meta");
   const tokenStrip = document.getElementById("token-strip");
   const tokenCanvas = document.getElementById("token-chart");
   const deceptionContainer = document.getElementById("deception-content");
 
+  let pageEvents = data.trace || [];
+  const baseEvents = data.trace || [];
+  const pageCache = new Map();
+  const shardCache = new Map();
+  let currentPage = 0;
+  let selectedIndex = 0;
+
+  const shardOffsets = [];
+  if (manifest && Array.isArray(manifest.shards)) {
+    let offset = 0;
+    manifest.shards.forEach((shard) => {
+      const events = shard.events || 0;
+      shardOffsets.push({
+        path: shard.path,
+        start: offset,
+        end: offset + events,
+      });
+      offset += events;
+    });
+  }
+  const totalEvents = manifest.total_events || baseEvents.length || (shardOffsets.length ? shardOffsets[shardOffsets.length - 1].end : 0);
+
+  const infoMessages = [];
+  function pushInfo(message) {
+    if (!message || infoMessages.includes(message)) return;
+    infoMessages.push(message);
+    infoBanner.textContent = infoMessages.join(" ");
+    infoBanner.style.display = infoMessages.length ? "block" : "none";
+  }
+
+  if (!tokens.length) {
+    pushInfo("Token log not provided; charts will be sparse.");
+  }
+  if (manifestPath === null && manifest && manifest.shards && manifest.shards.length) {
+    pushInfo("Manifest path missing; shard loading may fail depending on browser security settings.");
+  }
+  if (manifest && manifest.shards && manifest.shards.length) {
+    pushInfo(`Loaded manifest with ${manifest.shards.length} shard(s).`);
+  }
+
+  function resolveShardPath(shardPath) {
+    if (!manifestPath) return shardPath;
+    const parts = manifestPath.split(/[\\/]/);
+    parts.pop();
+    const base = parts.join("/");
+    if (!base) {
+      return shardPath;
+    }
+    return `${base}/${shardPath}`;
+  }
+
+  async function loadShard(shard) {
+    if (!shard || !shard.path) return [];
+    if (shardCache.has(shard.path)) {
+      return shardCache.get(shard.path);
+    }
+    if (shard.path.endsWith(".zst")) {
+      pushInfo("Compressed shards (.zst) cannot be loaded in-browser. Decompress to JSONL for full viewing.");
+      shardCache.set(shard.path, []);
+      return [];
+    }
+    const target = resolveShardPath(shard.path);
+    try {
+      const response = await fetch(target);
+      if (!response.ok) {
+        pushInfo(`Failed to fetch shard ${shard.path}: ${response.status}`);
+        shardCache.set(shard.path, []);
+        return [];
+      }
+      const text = await response.text();
+      const rows = text
+        .split(/\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          try {
+            return JSON.parse(line);
+          } catch (err) {
+            console.warn("Failed to parse shard line", err);
+            return null;
+          }
+        })
+        .filter(Boolean);
+      shardCache.set(shard.path, rows);
+      return rows;
+    } catch (err) {
+      pushInfo(`Unable to load shard ${shard.path}`);
+      shardCache.set(shard.path, []);
+      return [];
+    }
+  }
+
+  async function loadPage(page) {
+    if (pageCache.has(page)) {
+      return pageCache.get(page);
+    }
+    const start = page * pageSize;
+    const end = Math.min(start + pageSize, totalEvents);
+    if (!manifest.shards || !manifest.shards.length) {
+      const slice = baseEvents.slice(start, end);
+      pageCache.set(page, slice);
+      return slice;
+    }
+    const collected = [];
+    for (const shard of shardOffsets) {
+      if (shard.end <= start || shard.start >= end) {
+        continue;
+      }
+      const shardRows = await loadShard(shard);
+      if (!shardRows.length) {
+        continue;
+      }
+      const from = Math.max(start, shard.start) - shard.start;
+      const to = Math.min(end, shard.end) - shard.start;
+      const slice = shardRows.slice(from, to);
+      collected.push(...slice);
+      if (collected.length >= end - start) {
+        break;
+      }
+    }
+    const finalSlice = collected.slice(0, Math.max(0, end - start));
+    pageCache.set(page, finalSlice);
+    return finalSlice;
+  }
+
+  let prevBtn;
+  let nextBtn;
+  let pageInfo;
+
+  function initControls() {
+    controls.innerHTML = "";
+    prevBtn = document.createElement("button");
+    prevBtn.textContent = "Prev";
+    nextBtn = document.createElement("button");
+    nextBtn.textContent = "Next";
+    pageInfo = document.createElement("span");
+    pageInfo.className = "page-info";
+    controls.appendChild(prevBtn);
+    controls.appendChild(pageInfo);
+    controls.appendChild(nextBtn);
+    prevBtn.addEventListener("click", () => gotoPage(currentPage - 1));
+    nextBtn.addEventListener("click", () => gotoPage(currentPage + 1));
+  }
+
+  function updateControls() {
+    const maxPage = Math.max(0, Math.ceil(totalEvents / pageSize) - 1);
+    pageInfo.textContent = totalEvents
+      ? `Page ${currentPage + 1} / ${maxPage + 1} (${totalEvents} events)`
+      : "No events";
+    prevBtn.disabled = currentPage <= 0;
+    nextBtn.disabled = currentPage >= maxPage;
+  }
+
   function renderTimeline() {
     timelineList.innerHTML = "";
-    events.forEach((evt, index) => {
+    pageEvents.forEach((evt, index) => {
       const li = document.createElement("li");
-      li.textContent = `${evt.timestamp || index} – ${evt.stage || evt.module}`;
+      const label = evt.timestamp || evt.stage || evt.module || `Event ${index + 1}`;
+      const globalIndex = currentPage * pageSize + index;
+      li.textContent = `${globalIndex + 1}. ${label}`;
       li.addEventListener("click", () => selectEvent(index));
-      if (index === 0) {
+      if (index === selectedIndex) {
         li.classList.add("active");
       }
       timelineList.appendChild(li);
     });
-    if (events.length > 0) {
-      selectEvent(0);
+    if (pageEvents.length === 0) {
+      const empty = document.createElement("li");
+      empty.textContent = "No events loaded for this page.";
+      timelineList.appendChild(empty);
     }
   }
 
   function selectEvent(index) {
-    const evt = events[index];
-    eventText.textContent = evt.content || "";
+    if (!pageEvents[index]) {
+      return;
+    }
+    selectedIndex = index;
+    const evt = pageEvents[index];
+    eventText.textContent = evt.content || evt.text || "";
     eventMeta.innerHTML = "";
     const badges = (evt.gepa_hits || []).map((hit) => `<span class="badge">${hit}</span>`).join("");
     if (badges) {
@@ -45,6 +213,9 @@
     if (evt.context) {
       eventMeta.innerHTML += `<div>Context: ${evt.context}</div>`;
     }
+    if (evt.flags) {
+      eventMeta.innerHTML += `<div>Flags: ${JSON.stringify(evt.flags)}</div>`;
+    }
     const items = timelineList.querySelectorAll("li");
     items.forEach((node) => node.classList.remove("active"));
     if (items[index]) {
@@ -54,19 +225,28 @@
 
   function renderTokens() {
     tokenStrip.innerHTML = "";
-    tokens.forEach((token) => {
+    if (!tokens.length) {
+      return;
+    }
+    const step = Math.max(1, Math.floor(tokens.length / maxPoints));
+    const sampled = tokens.filter((_, idx) => idx % step === 0);
+    sampled.forEach((token) => {
       const span = document.createElement("span");
       span.textContent = token.token;
       span.className = "token-chip" + (token.abstained ? " abstain" : "");
+      span.title = `chunk ${token.chunk ?? 0} offset ${token.offset ?? 0} perplexity ${token.ppl ? token.ppl.toFixed(2) : "n/a"}`;
       tokenStrip.appendChild(span);
     });
     if (tokenCanvas && tokenCanvas.getContext) {
       const ctx = tokenCanvas.getContext("2d");
       ctx.clearRect(0, 0, tokenCanvas.width, tokenCanvas.height);
+      if (!sampled.length) {
+        return;
+      }
       ctx.strokeStyle = "#1f3c88";
       ctx.beginPath();
-      tokens.forEach((token, index) => {
-        const x = (index / Math.max(tokens.length - 1, 1)) * tokenCanvas.width;
+      sampled.forEach((token, index) => {
+        const x = (index / Math.max(sampled.length - 1, 1)) * tokenCanvas.width;
         const y = tokenCanvas.height - (token.conf || 0) * tokenCanvas.height * 0.8;
         if (index === 0) {
           ctx.moveTo(x, y);
@@ -88,17 +268,35 @@
       }
     }
     if (paired && paired.honest_chain) {
-      pieces.push('<h3>Honest Chain</h3>');
+      pieces.push("<h3>Honest Chain</h3>");
       pieces.push(`<pre>${JSON.stringify(paired.honest_chain, null, 2)}</pre>`);
     }
     if (paired && paired.deceptive_chain) {
-      pieces.push('<h3>Deceptive Chain</h3>');
+      pieces.push("<h3>Deceptive Chain</h3>");
       pieces.push(`<pre>${JSON.stringify(paired.deceptive_chain, null, 2)}</pre>`);
     }
     deceptionContainer.innerHTML = pieces.join("\n");
   }
 
-  renderTimeline();
-  renderTokens();
-  renderDeception();
+  async function gotoPage(page) {
+    const maxPage = Math.max(0, Math.ceil(Math.max(totalEvents, baseEvents.length) / pageSize) - 1);
+    currentPage = Math.min(Math.max(page, 0), maxPage);
+    pageEvents = await loadPage(currentPage);
+    selectedIndex = 0;
+    renderTimeline();
+    selectEvent(0);
+    updateControls();
+  }
+
+  async function init() {
+    initControls();
+    renderTokens();
+    renderDeception();
+    if (totalEvents === 0 && !baseEvents.length) {
+      pushInfo("No trace events available. Did the run complete?");
+    }
+    await gotoPage(0);
+  }
+
+  init();
 })();

--- a/tests/test_longctx_stream_score.py
+++ b/tests/test_longctx_stream_score.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from mindful_trace_gepa.cli import handle_score
+
+
+def _make_event(idx: int) -> dict:
+    return {
+        "content": f"Event {idx}",
+        "principle_scores": {"mindfulness": float(idx % 5)},
+        "imperative_scores": {"care": float(idx % 3)},
+        "flags": ["stream-test"],
+    }
+
+
+def test_streaming_score_large_trace(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    with trace_path.open("w", encoding="utf-8") as handle:
+        for idx in range(20_000):
+            handle.write(json.dumps(_make_event(idx)) + "\n")
+
+    out_path = tmp_path / "report.html"
+    args = argparse.Namespace(
+        trace=str(trace_path),
+        policy=None,
+        out=str(out_path),
+        stream=True,
+        sharded=False,
+        manifest=None,
+        zstd=False,
+    )
+
+    handle_score(args)
+
+    html = out_path.read_text(encoding="utf-8")
+    assert "Total events: 20000" in html or "20000" in html

--- a/tests/test_shards_manifest.py
+++ b/tests/test_shards_manifest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mindful_trace_gepa.storage import TraceArchiveWriter, iter_jsonl
+
+
+def test_sharded_manifest_creation(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    writer = TraceArchiveWriter(trace_path, shard_threshold=5)
+    for idx in range(12):
+        writer.append({"idx": idx, "content": f"event-{idx}"})
+    manifest_path = writer.close()
+
+    assert manifest_path is not None
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["total_events"] == 12
+    assert len(manifest["shards"]) >= 3
+
+    shard_counts = 0
+    for shard in manifest["shards"]:
+        shard_file = manifest_path.parent / shard["path"]
+        assert shard_file.exists()
+        events = list(iter_jsonl(shard_file))
+        shard_counts += len(events)
+    assert shard_counts == 12


### PR DESCRIPTION
## Summary
- add accelerate/deepspeed helpers plus shared training config and docs for distributed launches
- stream trace ingestion with sharding, manifest support, and long-context token logging alongside viewer pagination and manifest loading
- expose long-context model settings, retrieval utilities, and regression tests for streaming scoring and shard manifests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dfe1d61e2c8330a0d2a58438d61f8e