### PR TITLE
Fix tier aggregation config overrides

### DIFF
--- a/src/mindful_trace_gepa/scoring/aggregate.py
+++ b/src/mindful_trace_gepa/scoring/aggregate.py
@@ -49,8 +49,6 @@ def aggregate_tiers(tiers: Sequence[TierScores], config: Mapping[str, object] | 
             else:
                 cfg[key] = value
 
-        cfg.update(config)
-
     weight_cfg = cfg.get("weights", DEFAULT_CONFIG["weights"])
     thresholds = cfg.get("abstention_thresholds", DEFAULT_CONFIG["abstention_thresholds"])
     penalty = float(cfg.get("disagreement_penalty", DEFAULT_CONFIG["disagreement_penalty"]))


### PR DESCRIPTION
## Summary
- ensure aggregate tier config merging keeps default mapping entries when partially overridden

## Testing
- pytest tests/test_aggregate_confidence.py::test_partial_weight_override_preserves_defaults

------
https://chatgpt.com/codex/tasks/task_e_68e01727f0e483309e9710a1f19ef1df