### PR TITLE
Ensure scoring config merges nested mappings

### DIFF
--- a/src/mindful_trace_gepa/cli_scoring.py
+++ b/src/mindful_trace_gepa/cli_scoring.py
@@ -37,13 +37,29 @@ def _load_yaml(path: Path) -> Dict[str, Any]:
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
+def _clone_default_config() -> Dict[str, Any]:
+    cloned: Dict[str, Any] = {}
+    for key, value in DEFAULT_CONFIG.items():
+        if isinstance(value, Mapping):
+            cloned[key] = dict(value)
+        else:
+            cloned[key] = value
+    return cloned
+
+
 def _load_scoring_config(path: Path | None) -> Dict[str, Any]:
+    base = _clone_default_config()
     if path is None:
-        return dict(DEFAULT_CONFIG)
+        return base
     data = _load_yaml(path)
-    merged = dict(DEFAULT_CONFIG)
-    merged.update(data)
-    return merged
+    for key, value in data.items():
+        if isinstance(value, Mapping) and isinstance(base.get(key), Mapping):
+            merged = dict(base[key])
+            merged.update(value)
+            base[key] = merged
+        else:
+            base[key] = value
+    return base
 
 
 def _load_trace_events(path: Path) -> List[Dict[str, Any]]:

--- a/tests/test_cli_score_auto.py
+++ b/tests/test_cli_score_auto.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from mindful_trace_gepa.cli_scoring import handle_score_auto
+from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
 
 
 def test_score_auto_generates_output(tmp_path, monkeypatch):
@@ -38,3 +39,46 @@ def test_score_auto_generates_output(tmp_path, monkeypatch):
     assert "final" in payload and "confidence" in payload
     assert payload["per_tier"]
     assert any(tier["tier"] == "judge" for tier in payload["per_tier"])
+
+
+def test_score_auto_partial_weights_merge(tmp_path, monkeypatch):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(json.dumps({"content": "placeholder"}), encoding="utf-8")
+
+    config_path = tmp_path / "weights.yml"
+    config_path.write_text("weights:\n  judge: 0.4\n", encoding="utf-8")
+
+    def fake_run_heuristics(events):
+        scores = {dim: 4 for dim in DIMENSIONS}
+        confidence = {dim: 1.0 for dim in DIMENSIONS}
+        return TierScores(tier="heuristic", scores=scores, confidence=confidence, meta={})
+
+    class DummyJudge:
+        def __init__(self, config) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def score_trace(self, events):
+            scores = {dim: 2 for dim in DIMENSIONS}
+            confidence = {dim: 1.0 for dim in DIMENSIONS}
+            return TierScores(tier="judge", scores=scores, confidence=confidence, meta={})
+
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.run_heuristics", fake_run_heuristics)
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.LLMJudge", DummyJudge)
+
+    out_path = tmp_path / "scores.json"
+
+    args = argparse.Namespace(
+        trace=str(trace_path),
+        policy=None,
+        out=str(out_path),
+        config=str(config_path),
+        judge=True,
+        classifier=False,
+        classifier_config=None,
+        classifier_artifacts=None,
+        print=False,
+    )
+
+    handle_score_auto(args)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["final"]["mindfulness"] == 3


### PR DESCRIPTION
## Summary
- ensure `_load_scoring_config` clones defaults and merges nested mapping overrides instead of replacing them
- add a regression test covering partial weight overrides in the CLI scoring workflow

## Testing
- `PYTHONPATH=src pytest tests/test_cli_score_auto.py -k weights`


------
https://chatgpt.com/codex/tasks/task_e_68e12ed3b2a48330874d15a5054e7f0e