### PR TITLE
Harden scoring config handling for null overrides

### DIFF
--- a/src/mindful_trace_gepa/cli_scoring.py
+++ b/src/mindful_trace_gepa/cli_scoring.py
@@ -19,7 +19,7 @@ from .scoring import (
     run_heuristics,
     write_scoring_artifacts,
 )
-from .scoring.aggregate import DEFAULT_CONFIG
+from .scoring.aggregate import build_config
 from .scoring.llm_judge import JudgeConfig
 from .scoring.schema import AggregateScores, TierScores
 from .storage import iter_jsonl
@@ -37,29 +37,13 @@ def _load_yaml(path: Path) -> Dict[str, Any]:
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
-def _clone_default_config() -> Dict[str, Any]:
-    cloned: Dict[str, Any] = {}
-    for key, value in DEFAULT_CONFIG.items():
-        if isinstance(value, Mapping):
-            cloned[key] = dict(value)
-        else:
-            cloned[key] = value
-    return cloned
-
-
 def _load_scoring_config(path: Path | None) -> Dict[str, Any]:
-    base = _clone_default_config()
     if path is None:
-        return base
+        return build_config()
     data = _load_yaml(path)
-    for key, value in data.items():
-        if isinstance(value, Mapping) and isinstance(base.get(key), Mapping):
-            merged = dict(base[key])
-            merged.update(value)
-            base[key] = merged
-        else:
-            base[key] = value
-    return base
+    if not isinstance(data, Mapping):
+        return build_config()
+    return build_config(data)
 
 
 def _load_trace_events(path: Path) -> List[Dict[str, Any]]:

--- a/src/mindful_trace_gepa/scoring/aggregate.py
+++ b/src/mindful_trace_gepa/scoring/aggregate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import Dict, Iterable, List, Mapping, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
 from .schema import AggregateScores, DIMENSIONS, TierScores
 
@@ -19,8 +19,49 @@ DEFAULT_CONFIG = {
 }
 
 
-def _weight_for(tier: TierScores, config: Mapping[str, float]) -> float:
-    return float(config.get(tier.tier, 0.0))
+def _clone_mapping(mapping: Mapping[str, Any]) -> Dict[str, Any]:
+    cloned: Dict[str, Any] = {}
+    for key, value in mapping.items():
+        if isinstance(value, Mapping):
+            cloned[key] = _clone_mapping(value)
+        else:
+            cloned[key] = value
+    return cloned
+
+
+def _merge_mappings(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> Dict[str, Any]:
+    merged = _clone_mapping(base)
+    for key, value in overrides.items():
+        if value is None:
+            continue
+        base_value = merged.get(key)
+        if isinstance(base_value, Mapping) and isinstance(value, Mapping):
+            merged[key] = _merge_mappings(base_value, value)
+        elif isinstance(value, Mapping):
+            merged[key] = _merge_mappings({}, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def build_config(overrides: Mapping[str, Any] | None = None) -> Dict[str, Any]:
+    """Return a scoring config merged with :data:`DEFAULT_CONFIG`."""
+
+    if not isinstance(overrides, Mapping):
+        return _clone_mapping(DEFAULT_CONFIG)
+    return _merge_mappings(DEFAULT_CONFIG, overrides)
+
+
+def _safe_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _weight_for(tier: TierScores, config: Mapping[str, Any]) -> float:
+    raw = config.get(tier.tier, 0.0) if isinstance(config, Mapping) else 0.0
+    return _safe_float(raw, 0.0)
 
 
 def _pairwise_disagreement(scores: Sequence[TierScores]) -> Dict[str, int]:
@@ -38,21 +79,32 @@ def aggregate_tiers(tiers: Sequence[TierScores], config: Mapping[str, object] | 
     if not tiers:
         raise ValueError("At least one tier score is required for aggregation")
 
-    cfg = dict(DEFAULT_CONFIG)
-    if config:
+    cfg = build_config(config)
 
-        for key, value in config.items():
-            if key in {"weights", "abstention_thresholds"} and isinstance(value, Mapping):
-                merged = dict(DEFAULT_CONFIG[key])
-                merged.update(value)
-                cfg[key] = merged
-            else:
-                cfg[key] = value
+    weight_cfg_obj = cfg.get("weights", DEFAULT_CONFIG["weights"])
+    if not isinstance(weight_cfg_obj, Mapping):
+        weight_cfg_obj = DEFAULT_CONFIG["weights"]
+    weight_cfg = dict(weight_cfg_obj)
 
-    weight_cfg = cfg.get("weights", DEFAULT_CONFIG["weights"])
-    thresholds = cfg.get("abstention_thresholds", DEFAULT_CONFIG["abstention_thresholds"])
-    penalty = float(cfg.get("disagreement_penalty", DEFAULT_CONFIG["disagreement_penalty"]))
-    escalate_floor = float(cfg.get("escalate_if_any_below", DEFAULT_CONFIG["escalate_if_any_below"]))
+    thresholds_obj = cfg.get("abstention_thresholds", DEFAULT_CONFIG["abstention_thresholds"])
+    if not isinstance(thresholds_obj, Mapping):
+        thresholds_obj = DEFAULT_CONFIG["abstention_thresholds"]
+    thresholds = dict(thresholds_obj)
+
+    default_thresholds = DEFAULT_CONFIG["abstention_thresholds"]
+    penalty = _safe_float(
+        cfg.get("disagreement_penalty", DEFAULT_CONFIG["disagreement_penalty"]),
+        DEFAULT_CONFIG["disagreement_penalty"],
+    )
+    escalate_floor = _safe_float(
+        cfg.get("escalate_if_any_below", DEFAULT_CONFIG["escalate_if_any_below"]),
+        DEFAULT_CONFIG["escalate_if_any_below"],
+    )
+
+    threshold_values = {
+        dim: _safe_float(thresholds.get(dim, default_thresholds.get(dim, 0.75)), default_thresholds.get(dim, 0.75))
+        for dim in DIMENSIONS
+    }
 
     final_scores: Dict[str, int] = {}
     final_confidence: Dict[str, float] = {}
@@ -83,11 +135,11 @@ def aggregate_tiers(tiers: Sequence[TierScores], config: Mapping[str, object] | 
         final_confidence[dim] = adjusted_conf
         if disagreement_gap >= 2:
             reasons.append(f"{dim}: high tier disagreement (gap={disagreement_gap})")
-        threshold = float(thresholds.get(dim, 0.75))
+        threshold = threshold_values[dim]
         if adjusted_conf < threshold:
             reasons.append(f"{dim}: confidence {adjusted_conf:.2f} below threshold {threshold:.2f}")
 
-    escalate = any(final_confidence[dim] < float(thresholds.get(dim, 0.75)) for dim in DIMENSIONS)
+    escalate = any(final_confidence[dim] < threshold_values[dim] for dim in DIMENSIONS)
     if any(gaps[dim] >= 2 for dim in DIMENSIONS):
         escalate = True
     if any(final_confidence[dim] < escalate_floor for dim in DIMENSIONS):
@@ -103,4 +155,4 @@ def aggregate_tiers(tiers: Sequence[TierScores], config: Mapping[str, object] | 
     )
 
 
-__all__ = ["aggregate_tiers"]
+__all__ = ["aggregate_tiers", "DEFAULT_CONFIG", "build_config"]

--- a/tests/test_cli_score_auto.py
+++ b/tests/test_cli_score_auto.py
@@ -1,8 +1,5 @@
 import json
-import json
 import argparse
-import os
-from pathlib import Path
 
 from mindful_trace_gepa.cli_scoring import handle_score_auto
 from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
@@ -76,6 +73,62 @@ def test_score_auto_partial_weights_merge(tmp_path, monkeypatch):
         classifier=False,
         classifier_config=None,
         classifier_artifacts=None,
+        print=False,
+    )
+
+    handle_score_auto(args)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["final"]["mindfulness"] == 3
+
+
+def test_score_auto_none_classifier_weight_uses_default(tmp_path, monkeypatch):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(json.dumps({"content": "placeholder"}), encoding="utf-8")
+
+    config_path = tmp_path / "weights.yml"
+    config_path.write_text("weights:\n  judge: 0.4\n  classifier: null\n", encoding="utf-8")
+
+    def fake_run_heuristics(events):
+        scores = {dim: 4 for dim in DIMENSIONS}
+        confidence = {dim: 1.0 for dim in DIMENSIONS}
+        return TierScores(tier="heuristic", scores=scores, confidence=confidence, meta={})
+
+    class DummyJudge:
+        def __init__(self, config) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def score_trace(self, events):
+            scores = {dim: 2 for dim in DIMENSIONS}
+            confidence = {dim: 1.0 for dim in DIMENSIONS}
+            return TierScores(tier="judge", scores=scores, confidence=confidence, meta={})
+
+    class DummyClassifier:
+        def __init__(self, config) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def load(self, path):  # pragma: no cover - stub does nothing
+            return None
+
+        def predict(self, events):
+            scores = {dim: 4 for dim in DIMENSIONS}
+            confidence = {dim: 1.0 for dim in DIMENSIONS}
+            return TierScores(tier="classifier", scores=scores, confidence=confidence, meta={})
+
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.run_heuristics", fake_run_heuristics)
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.LLMJudge", DummyJudge)
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.load_classifier_from_config", lambda path: DummyClassifier(path))
+
+    out_path = tmp_path / "scores.json"
+
+    args = argparse.Namespace(
+        trace=str(trace_path),
+        policy=None,
+        out=str(out_path),
+        config=str(config_path),
+        judge=True,
+        classifier=True,
+        classifier_config="unused",
+        classifier_artifacts=str(tmp_path / "artifacts"),
         print=False,
     )
 


### PR DESCRIPTION
## Summary
- ensure scoring config merges deep-copy defaults, skip null overrides, and expose a reusable builder
- update the CLI to consume the shared config builder for YAML/JSON overrides
- add regression coverage for classifier weight overrides that leave entries null

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e016c0fd988330941a2f735dd1bd0a