### PR TITLE
Fix labels exporter to use AggregateScores.from_dict

### DIFF
--- a/scripts/labels_export.py
+++ b/scripts/labels_export.py
@@ -12,7 +12,7 @@ from mindful_trace_gepa.scoring.schema import AggregateScores
 
 def export_low_confidence(scores_path: Path, threshold: float) -> List[Dict[str, Any]]:
     payload = json.loads(scores_path.read_text(encoding="utf-8"))
-    aggregate = AggregateScores.parse_obj(payload)
+    aggregate = AggregateScores.from_dict(payload)
     rows: List[Dict[str, Any]] = []
     for dim, conf in aggregate.confidence.items():
         if conf < threshold:


### PR DESCRIPTION
## Summary
- construct AggregateScores via from_dict so the labels exporter can read JSON payloads

## Testing
- PYTHONPATH=src python scripts/labels_export.py --scores /tmp/sample_scores.json --out /tmp/output.jsonl --threshold 0.65

------
https://chatgpt.com/codex/tasks/task_e_68e2777749c883308b7f41b04a83bc4a