### PR TITLE
Add configurable logging output for training CLI

### DIFF
--- a/gepa_mindfulness/training/__init__.py
+++ b/gepa_mindfulness/training/__init__.py
@@ -1,9 +1,15 @@
 """Training utilities for GEPA mindfulness."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .cli import main as cli_main
 from .configs import TrainingConfig, load_training_config
-from .pipeline import TrainingOrchestrator
-from .reporting import SummaryReport, describe_reward, render_summary
+
+if TYPE_CHECKING:  # pragma: no cover - import only for static analysis
+    from .pipeline import TrainingOrchestrator
+    from .reporting import SummaryReport, describe_reward, render_summary
 
 __all__ = [
     "TrainingConfig",
@@ -14,3 +20,20 @@ __all__ = [
     "describe_reward",
     "render_summary",
 ]
+
+
+def __getattr__(name: str):  # pragma: no cover - simple lazy import helper
+    if name == "TrainingOrchestrator":
+        from .pipeline import TrainingOrchestrator
+
+        return TrainingOrchestrator
+    if name in {"SummaryReport", "describe_reward", "render_summary"}:
+        from .reporting import SummaryReport, describe_reward, render_summary
+
+        mapping = {
+            "SummaryReport": SummaryReport,
+            "describe_reward": describe_reward,
+            "render_summary": render_summary,
+        }
+        return mapping[name]
+    raise AttributeError(name)

--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import importlib
+import json
 import logging
+import os
+import sys
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
+from typing import Callable, Iterable, TYPE_CHECKING
 
 from ..core.adversarial import iterate_adversarial_pool
 from .configs import TrainingConfig, load_training_config
-from .pipeline import TrainingOrchestrator
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
+    from .pipeline import TrainingOrchestrator
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +40,66 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Only run adversarial evaluation without PPO updates.",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help="Directory where training logs and rollout data will be written.",
+    )
+    args = parser.parse_args()
+
+    assume_tty = os.environ.get("GEPA_MINDFULNESS_TRAINING_ASSUME_TTY") == "1"
+    if args.log_dir is None:
+        if sys.stdin.isatty() or assume_tty:
+            destination: str = ""
+            while not destination:
+                destination = input("Enter log output directory path: ").strip()
+            args.log_dir = Path(destination).expanduser()
+        else:
+            parser.error("--log-dir is required when standard input is not interactive")
+    else:
+        args.log_dir = args.log_dir.expanduser()
+
+    return args
+
+
+def _resolve_orchestrator_factory() -> Callable[[TrainingConfig], object]:
+    override = os.environ.get("GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR")
+    if not override:
+        from .pipeline import TrainingOrchestrator
+
+        return TrainingOrchestrator
+    module_name, _, attribute = override.partition(":")
+    if not module_name or not attribute:
+        raise ValueError(
+            "GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR must be in 'module:callable' format"
+        )
+    module = importlib.import_module(module_name)
+    factory = getattr(module, attribute)
+    if not callable(factory):
+        raise TypeError(
+            "GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR must reference a callable"
+        )
+    return factory
+
+
+def _serialize_rollouts(path: Path, results: Iterable[object]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for item in results:
+            if is_dataclass(item):
+                payload = asdict(item)
+            else:
+                payload = {
+                    "prompt": getattr(item, "prompt", None),
+                    "response": getattr(item, "response", None),
+                    "reward": getattr(item, "reward", None),
+                    "trace_summary": getattr(item, "trace_summary", None),
+                    "contradiction_report": getattr(
+                        item, "contradiction_report", None
+                    ),
+                }
+            json.dump(payload, handle)
+            handle.write("\n")
 
 
 def read_dataset(path: Path) -> list[str]:
@@ -41,10 +108,24 @@ def read_dataset(path: Path) -> list[str]:
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
     args = parse_args()
+    log_dir: Path = args.log_dir
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(level=logging.INFO)
+    root_logger = logging.getLogger()
+    log_file = log_dir / "training.log"
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    root_logger.addHandler(file_handler)
+    LOGGER.info("File logging enabled at %s", log_file)
+
     config: TrainingConfig = load_training_config(args.config)
-    orchestrator = TrainingOrchestrator(config=config)
+    orchestrator_factory = _resolve_orchestrator_factory()
+    orchestrator = orchestrator_factory(config=config)
     prompts = read_dataset(args.dataset)
 
     if args.adversarial_only:
@@ -53,6 +134,10 @@ def main() -> None:
     else:
         LOGGER.info("Running PPO training")
         results = orchestrator.run(prompts)
+
+    rollout_path = log_dir / "rollouts.jsonl"
+    _serialize_rollouts(rollout_path, results)
+    LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
 
     LOGGER.info("Completed %s rollouts", len(results))
     for idx, result in enumerate(results):

--- a/tests/test_training_cli_logging.py
+++ b/tests/test_training_cli_logging.py
@@ -1,0 +1,194 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+STUB_MODULE = """
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class StubRollout:
+    prompt: str
+    response: str
+    reward: float
+    trace_summary: dict
+    contradiction_report: dict
+
+
+class StubTrainingOrchestrator:
+    def __init__(self, config) -> None:
+        self.config = config
+
+    def run(self, prompts: Iterable[str]) -> List[StubRollout]:
+        prompts_list = list(prompts)
+        prompt = prompts_list[0] if prompts_list else ""
+        return [
+            StubRollout(
+                prompt=prompt,
+                response="stub-response",
+                reward=1.23,
+                trace_summary={"trace": True},
+                contradiction_report={"conflict": False},
+            )
+        ]
+
+    def run_adversarial_eval(self) -> List[StubRollout]:
+        return []
+
+
+def create_orchestrator(config) -> StubTrainingOrchestrator:
+    return StubTrainingOrchestrator(config)
+"""
+
+
+PYDANTIC_STUB = """
+_MISSING = object()
+
+
+class _FieldInfo:
+    def __init__(self, default=_MISSING, default_factory=None, **_kwargs):
+        self.default = default
+        self.default_factory = default_factory
+
+
+def Field(default=_MISSING, *, default_factory=None, **_kwargs):
+    return _FieldInfo(default=default, default_factory=default_factory)
+
+
+def validator(*_args, **_kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+class BaseModel:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.__fields__ = {}
+        cls.__annotations__ = getattr(cls, "__annotations__", {})
+        for name in cls.__annotations__:
+            cls.__fields__[name] = getattr(cls, name, _MISSING)
+
+    def __init__(self, **data):
+        for name, default in self.__class__.__fields__.items():
+            if name in data:
+                value = data[name]
+            else:
+                value = self._resolve_default(default)
+
+            annotation = self.__class__.__annotations__.get(name)
+            if isinstance(value, dict) and isinstance(annotation, type) and issubclass(
+                annotation, BaseModel
+            ):
+                value = annotation.parse_obj(value)
+            setattr(self, name, value)
+
+    @staticmethod
+    def _resolve_default(default):
+        if isinstance(default, _FieldInfo):
+            if default.default_factory is not None:
+                return default.default_factory()
+            if default.default is not _MISSING:
+                return default.default
+            return None
+        if default is _MISSING:
+            return None
+        if isinstance(default, type) and issubclass(default, BaseModel):
+            return default()
+        return default
+
+    @classmethod
+    def parse_obj(cls, obj):
+        return cls(**obj)
+
+    def dict(self):
+        result = {}
+        for name in self.__class__.__fields__:
+            value = getattr(self, name)
+            if isinstance(value, BaseModel):
+                result[name] = value.dict()
+            else:
+                result[name] = value
+        return result
+"""
+
+
+def _prepare_environment(tmp_path: Path) -> dict[str, str]:
+    stub_path = tmp_path / "training_stub.py"
+    stub_path.write_text(STUB_MODULE, encoding="utf-8")
+    (tmp_path / "pydantic.py").write_text(PYDANTIC_STUB, encoding="utf-8")
+
+    env = os.environ.copy()
+    project_root = Path(__file__).resolve().parents[1]
+    src_dir = project_root / "src"
+    extras = [env.get("PYTHONPATH", ""), str(project_root), str(src_dir), str(tmp_path)]
+    env["PYTHONPATH"] = os.pathsep.join(path for path in extras if path)
+    env["GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR"] = "training_stub:create_orchestrator"
+    env["GEPA_MINDFULNESS_TRAINING_ASSUME_TTY"] = "1"
+    return env
+
+
+def _run_cli(args: list[str], env: dict[str, str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "gepa_mindfulness.training.cli", *args],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    stdout, stderr = proc.communicate(input_text)
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+
+
+def test_training_cli_prompts_and_logs(tmp_path: Path) -> None:
+    env = _prepare_environment(tmp_path)
+    dataset = tmp_path / "dataset.txt"
+    dataset.write_text("test prompt\n", encoding="utf-8")
+    config = tmp_path / "config.yml"
+    config.write_text("{}\n", encoding="utf-8")
+
+    # When --log-dir is omitted the CLI should request one interactively.
+    interactive_log_dir = tmp_path / "interactive_logs"
+    result = _run_cli(
+        ["--config", str(config), "--dataset", str(dataset)],
+        env=env,
+        input_text=f"{interactive_log_dir}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Enter log output directory path" in result.stdout
+    training_log = interactive_log_dir / "training.log"
+    rollouts_log = interactive_log_dir / "rollouts.jsonl"
+    assert training_log.exists()
+    assert rollouts_log.exists()
+
+    with rollouts_log.open("r", encoding="utf-8") as handle:
+        lines = [json.loads(line) for line in handle if line.strip()]
+    assert lines and lines[0]["response"] == "stub-response"
+
+    # When --log-dir is provided the CLI should write the logs without prompting.
+    provided_log_dir = tmp_path / "provided_logs"
+    result_with_flag = _run_cli(
+        [
+            "--config",
+            str(config),
+            "--dataset",
+            str(dataset),
+            "--log-dir",
+            str(provided_log_dir),
+        ],
+        env=env,
+    )
+    assert result_with_flag.returncode == 0, result_with_flag.stderr
+    assert "Enter log output directory path" not in result_with_flag.stdout
+    file_log = provided_log_dir / "training.log"
+    jsonl_log = provided_log_dir / "rollouts.jsonl"
+    assert file_log.exists()
+    assert jsonl_log.exists()
+    contents = file_log.read_text(encoding="utf-8")
+    assert "Serialized 1 rollouts" in contents


### PR DESCRIPTION
## Summary
- extend the training CLI to request or accept a log directory and support dependency injection for the orchestrator
- add file logging and JSONL serialization of rollout results in the configured directory
- add a regression test that exercises the CLI via subprocess to cover prompting and log file emission

## Testing
- pytest tests/test_training_cli_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e279c39d788330b4177d8b558861d6