### PR TITLE
Add log directory prompting and logging to training CLI

### DIFF
--- a/gepa_mindfulness/adapters/__init__.py
+++ b/gepa_mindfulness/adapters/__init__.py
@@ -1,4 +1,5 @@
 """Adapter exports for GEPA mindfulness."""
+
 from .policy_adapter import HuggingFaceGenerator, TextGenerator, VLLMGenerator
 from .tracing_adapter import TraceToCheckpoint, generate_checkpoints
 

--- a/gepa_mindfulness/adapters/policy_adapter.py
+++ b/gepa_mindfulness/adapters/policy_adapter.py
@@ -1,20 +1,20 @@
 """Abstraction for policy model generation supporting vLLM or HF backends."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Protocol
+from typing import Any, Iterable, Protocol
 
 
 class TextGenerator(Protocol):
-    def __call__(self, prompts: Iterable[str]) -> Iterable[str]:
-        ...
+    def __call__(self, prompts: Iterable[str]) -> Iterable[str]: ...
 
 
 @dataclass
 class HuggingFaceGenerator:
-    tokenizer: any
-    model: any
-    device: any
+    tokenizer: Any
+    model: Any
+    device: Any
 
     def __call__(self, prompts: Iterable[str]) -> Iterable[str]:
         from torch import no_grad

--- a/gepa_mindfulness/adapters/tracing_adapter.py
+++ b/gepa_mindfulness/adapters/tracing_adapter.py
@@ -1,4 +1,5 @@
 """Adapters bridging policy rollouts with self-tracing artifacts."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/gepa_mindfulness/core/__init__.py
+++ b/gepa_mindfulness/core/__init__.py
@@ -1,7 +1,8 @@
 """Core GEPA logic exports."""
+
 from .abstention import ABSTAIN_OUTPUT, ConfidenceDecision, enforce_abstention
 from .adversarial import AdversarialScenario, iterate_adversarial_pool, sample_adversarial_batch
-from .contemplative_principles import ContemplativePrinciple, GEPAPrincipleScore, GEPAPrinciples
+from .contemplative_principles import ContemplativePrinciple, GEPAPrinciples, GEPAPrincipleScore
 from .imperatives import AlignmentImperative, ImperativeEvaluator, ImperativeSignal
 from .paraconsistent import ParaconsistentTruthValue, dialetheic_and
 from .rewards import RewardSignal, RewardWeights

--- a/gepa_mindfulness/core/abstention.py
+++ b/gepa_mindfulness/core/abstention.py
@@ -1,9 +1,9 @@
 """Confidence-aware abstention utilities."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Dict, Tuple
-
 
 ABSTAIN_OUTPUT = "I don't know"
 
@@ -15,7 +15,9 @@ class ConfidenceDecision:
     metadata: Dict[str, float]
 
 
-def enforce_abstention(raw_output: str, confidence: float, threshold: float = 0.75) -> ConfidenceDecision:
+def enforce_abstention(
+    raw_output: str, confidence: float, threshold: float = 0.75
+) -> ConfidenceDecision:
     """Return abstain output whenever confidence falls below the threshold."""
 
     decision = ConfidenceDecision(

--- a/gepa_mindfulness/core/adversarial.py
+++ b/gepa_mindfulness/core/adversarial.py
@@ -1,4 +1,5 @@
 """Adversarial and out-of-distribution challenge utilities."""
+
 from __future__ import annotations
 
 import random

--- a/gepa_mindfulness/core/contemplative_principles.py
+++ b/gepa_mindfulness/core/contemplative_principles.py
@@ -1,4 +1,5 @@
 """Definitions for GEPA contemplative principles."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/gepa_mindfulness/core/imperatives.py
+++ b/gepa_mindfulness/core/imperatives.py
@@ -1,4 +1,5 @@
 """Alignment imperative modeling with paraconsistent evaluation."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -48,10 +49,11 @@ class ImperativeEvaluator:
     def aggregate(self) -> ParaconsistentTruthValue:
         if not self.signals:
             raise ValueError("At least one imperative signal required.")
-        truth = None
-        for signal in self.signals.values():
-            value = signal.to_paraconsistent()
-            truth = value if truth is None else dialetheic_and(truth, value)
+        iterator = iter(self.signals.values())
+        first_signal = next(iterator)
+        truth = first_signal.to_paraconsistent()
+        for signal in iterator:
+            truth = dialetheic_and(truth, signal.to_paraconsistent())
         return truth
 
     def contradiction_report(self) -> Dict[str, float]:

--- a/gepa_mindfulness/core/paraconsistent.py
+++ b/gepa_mindfulness/core/paraconsistent.py
@@ -1,4 +1,5 @@
 """Minimal paraconsistent logic primitives."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,7 +13,9 @@ class ParaconsistentTruthValue:
     opposition: float
 
     @classmethod
-    def from_support_opposition(cls, support: float, opposition: float) -> "ParaconsistentTruthValue":
+    def from_support_opposition(
+        cls, support: float, opposition: float
+    ) -> "ParaconsistentTruthValue":
         if not 0.0 <= support <= 1.0:
             raise ValueError("support must be within [0, 1]")
         if not 0.0 <= opposition <= 1.0:
@@ -40,7 +43,9 @@ class ParaconsistentTruthValue:
         return self.support - self.opposition
 
 
-def dialetheic_and(left: ParaconsistentTruthValue, right: ParaconsistentTruthValue) -> ParaconsistentTruthValue:
+def dialetheic_and(
+    left: ParaconsistentTruthValue, right: ParaconsistentTruthValue
+) -> ParaconsistentTruthValue:
     """Combine two paraconsistent truth values using a cautious conjunction."""
 
     support = min(left.support, right.support)

--- a/gepa_mindfulness/core/rewards.py
+++ b/gepa_mindfulness/core/rewards.py
@@ -1,4 +1,5 @@
 """Reward shaping utilities for PPO training."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/gepa_mindfulness/core/tracing.py
+++ b/gepa_mindfulness/core/tracing.py
@@ -1,15 +1,47 @@
 """Integration layer for Anthropic-style self-tracing."""
+
 from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    cast,
+)
 
-try:  # pragma: no cover - optional dependency
-    from self_tracing import Tracer  # type: ignore
-except Exception:  # pragma: no cover - fallback when package missing
-    Tracer = None  # type: ignore
+from mindful_trace_gepa.utils.imports import optional_import
+
+
+class TracerProtocol(Protocol):
+    """Minimal protocol implemented by ``self_tracing.Tracer``."""
+
+    def span(self, **context: Any) -> ContextManager[Any]: ...
+
+    def log(self, *, stage: str, content: str, **metadata: Any) -> None: ...
+
+
+_TRACER_MODULE = optional_import("self_tracing")
+TracerFactory: Callable[[], TracerProtocol] | None
+if _TRACER_MODULE is not None:
+    candidate = getattr(_TRACER_MODULE, "Tracer", None)
+    TracerFactory = candidate if callable(candidate) else None
+else:  # pragma: no cover - optional dependency missing
+    TracerFactory = None
+
+
+def _create_tracer() -> TracerProtocol | None:
+    if TracerFactory is None:
+        return None
+    tracer = TracerFactory()
+    return cast(TracerProtocol, tracer)
 
 
 TRACE_STAGES = ["framing", "evidence", "tensions", "decision", "reflection"]
@@ -53,19 +85,21 @@ class SelfTracingLogger:
     """Wrapper that gracefully falls back if the optional dependency is missing."""
 
     def __init__(self) -> None:
-        self._tracer = Tracer() if Tracer is not None else None
+        self._tracer = _create_tracer()
         self._active_traces: List[ThoughtTrace] = []
 
     @contextlib.contextmanager
-    def trace(self, **context: Any) -> Iterable[ThoughtTrace]:
+    def trace(self, **context: Any) -> Iterator[ThoughtTrace]:
         trace = ThoughtTrace()
         self._active_traces.append(trace)
-        if self._tracer is not None:
-            with self._tracer.span(**context):  # type: ignore[attr-defined]
+        try:
+            if self._tracer is not None:
+                with self._tracer.span(**context):
+                    yield trace
+            else:
                 yield trace
-        else:
-            yield trace
-        self._active_traces.pop()
+        finally:
+            self._active_traces.pop()
 
     def log_event(self, stage: str, content: str, **metadata: Any) -> None:
         if not self._active_traces:
@@ -73,7 +107,7 @@ class SelfTracingLogger:
         trace = self._active_traces[-1]
         trace.add_event(stage, content, **metadata)
         if self._tracer is not None:
-            self._tracer.log(stage=stage, content=content, **metadata)  # type: ignore[attr-defined]
+            self._tracer.log(stage=stage, content=content, **metadata)
 
     @property
     def latest_trace(self) -> Optional[ThoughtTrace]:

--- a/gepa_mindfulness/examples/cpu_demo/run_cpu_demo.py
+++ b/gepa_mindfulness/examples/cpu_demo/run_cpu_demo.py
@@ -1,4 +1,5 @@
 """Minimal CPU-only demonstration of the training pipeline."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/gepa_mindfulness/examples/vllm_demo/run_vllm_demo.py
+++ b/gepa_mindfulness/examples/vllm_demo/run_vllm_demo.py
@@ -1,4 +1,5 @@
 """vLLM targeted demonstration using preconfigured engine endpoint."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -17,13 +18,15 @@ def main() -> None:
     orchestrator = TrainingOrchestrator(config=config)
     results = orchestrator.run(SAMPLE_PROMPTS)
     for result in results:
-        print({
-            "prompt": result.prompt,
-            "response": result.response,
-            "reward": result.reward,
-            "trace": result.trace_summary,
-            "contradictions": result.contradiction_report,
-        })
+        print(
+            {
+                "prompt": result.prompt,
+                "response": result.response,
+                "reward": result.reward,
+                "trace": result.trace_summary,
+                "contradictions": result.contradiction_report,
+            }
+        )
 
 
 if __name__ == "__main__":

--- a/gepa_mindfulness/metrics.py
+++ b/gepa_mindfulness/metrics.py
@@ -1,4 +1,5 @@
 """Aggregators for GEPA mindfulness practice sessions."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -6,15 +7,15 @@ from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from math import isfinite
 from numbers import Real
-from typing import Iterable, Iterator, Tuple, Union
+from typing import Any, Iterable, Iterator, Tuple, Union
 
-_DECIMAL_ZERO = Decimal("0")
-_DECIMAL_ONE = Decimal("1")
+_DECIMAL_ZERO = Decimal(0)
+_DECIMAL_ONE = Decimal(1)
 
 NumberLike = Union[Real, Decimal, Fraction]
 
 
-def _ensure_numeric(label: str, value: object) -> None:
+def _ensure_numeric(label: str, value: Any) -> None:
     """Ensure *value* behaves like a real number.
 
     ``bool`` instances and ``str``/``bytes`` values are rejected explicitly so
@@ -36,7 +37,7 @@ def _ensure_numeric(label: str, value: object) -> None:
         raise TypeError(f"{label} must be a real number") from exc
 
 
-def _to_decimal(label: str, value: NumberLike | object) -> Decimal:
+def _to_decimal(label: str, value: Any) -> Decimal:
     """Coerce *value* into :class:`~decimal.Decimal` with sanity checks."""
 
     if isinstance(value, Decimal):
@@ -62,7 +63,7 @@ def _to_decimal(label: str, value: NumberLike | object) -> Decimal:
     # Fallback for float-like objects that are not ``Real`` (e.g. numpy
     # scalar-like wrappers used in the tests).
     try:
-        numeric = float(value)  # type: ignore[arg-type]
+        numeric = float(value)
     except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
         raise TypeError(f"{label} must be a real number") from exc
 
@@ -91,7 +92,7 @@ def _decimal_to_float(label: str, value: Decimal) -> float:
     return result
 
 
-def _coerce_duration(value: object) -> Decimal:
+def _coerce_duration(value: Any) -> Decimal:
     _ensure_numeric("duration_minutes", value)
     duration = _to_decimal("duration_minutes", value)
     if duration < _DECIMAL_ZERO:
@@ -99,7 +100,7 @@ def _coerce_duration(value: object) -> Decimal:
     return duration
 
 
-def _coerce_score(label: str, value: object) -> Decimal:
+def _coerce_score(label: str, value: Any) -> Decimal:
     _ensure_numeric(label, value)
 
     if isinstance(value, Fraction):
@@ -118,11 +119,11 @@ def _coerce_score(label: str, value: object) -> Decimal:
 class PracticeSession:
     """Container describing a mindfulness practice session."""
 
-    duration_minutes: NumberLike | object
-    grounding: NumberLike | object
-    equanimity: NumberLike | object
-    purpose: NumberLike | object
-    awareness: NumberLike | object
+    duration_minutes: Any
+    grounding: Any
+    equanimity: Any
+    purpose: Any
+    awareness: Any
 
     def validate(self) -> None:
         """Ensure the session contains sane numeric values."""
@@ -136,7 +137,7 @@ class PracticeSession:
             score = _coerce_score(label, value)
             _decimal_to_float(label, score)
 
-    def _iter_scores(self) -> Iterator[Tuple[str, object]]:
+    def _iter_scores(self) -> Iterator[Tuple[str, Any]]:
         yield "grounding", self.grounding
         yield "equanimity", self.equanimity
         yield "purpose", self.purpose
@@ -161,11 +162,11 @@ class AggregateResult:
 def aggregate_gepa_metrics(sessions: Iterable[PracticeSession]) -> AggregateResult:
     """Compute a duration-weighted aggregate GEPA score."""
 
-    total_duration = Decimal("0")
-    grounding_total = Decimal("0")
-    equanimity_total = Decimal("0")
-    purpose_total = Decimal("0")
-    awareness_total = Decimal("0")
+    total_duration = Decimal(0)
+    grounding_total = Decimal(0)
+    equanimity_total = Decimal(0)
+    purpose_total = Decimal(0)
+    awareness_total = Decimal(0)
 
     for session in sessions:
         session.validate()

--- a/gepa_mindfulness/training/__init__.py
+++ b/gepa_mindfulness/training/__init__.py
@@ -1,7 +1,8 @@
 """Training utilities for GEPA mindfulness."""
+
+from .cli import main as cli_main
 from .configs import TrainingConfig, load_training_config
 from .pipeline import TrainingOrchestrator
-from .cli import main as cli_main
 from .reporting import SummaryReport, describe_reward, render_summary
 
 __all__ = [

--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -1,13 +1,17 @@
 """Command line entry points for the training pipeline."""
+
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import sys
+from dataclasses import asdict
 from pathlib import Path
 
 from ..core.adversarial import iterate_adversarial_pool
 from .configs import TrainingConfig, load_training_config
-from .pipeline import TrainingOrchestrator
+from .pipeline import RolloutResult, TrainingOrchestrator
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +35,15 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Only run adversarial evaluation without PPO updates.",
     )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory where training logs and rollout summaries will be written. "
+            "If omitted in an interactive shell, the CLI prompts for a location."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -39,27 +52,66 @@ def read_dataset(path: Path) -> list[str]:
         return [line.strip() for line in handle if line.strip()]
 
 
+def _resolve_log_dir(cli_arg: Path | None) -> Path:
+    if cli_arg is not None:
+        return cli_arg.expanduser().resolve()
+
+    if sys.stdin.isatty():
+        destination = input("Enter a directory to store training logs: ").strip()
+        if not destination:
+            raise SystemExit("A log directory is required when running interactively.")
+        return Path(destination).expanduser().resolve()
+
+    raise SystemExit("--log-dir must be provided when stdin is not interactive.")
+
+
+def _write_rollout_log(log_dir: Path, results: list[RolloutResult]) -> None:
+    rollout_path = log_dir / "rollouts.jsonl"
+    with rollout_path.open("w", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(json.dumps(asdict(result), ensure_ascii=False) + "\n")
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     args = parse_args()
+    log_dir = _resolve_log_dir(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    file_handler = logging.FileHandler(log_dir / "training.log", encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    root_logger = logging.getLogger()
+    root_logger.addHandler(file_handler)
+
     config: TrainingConfig = load_training_config(args.config)
     orchestrator = TrainingOrchestrator(config=config)
     prompts = read_dataset(args.dataset)
 
-    if args.adversarial_only:
-        LOGGER.info("Running adversarial evaluation only")
-        results = orchestrator.run_adversarial_eval()
-    else:
-        LOGGER.info("Running PPO training")
-        results = orchestrator.run(prompts)
+    try:
+        if args.adversarial_only:
+            LOGGER.info("Running adversarial evaluation only")
+            results = orchestrator.run_adversarial_eval()
+        else:
+            LOGGER.info("Running PPO training")
+            results = orchestrator.run(prompts)
 
-    LOGGER.info("Completed %s rollouts", len(results))
-    for idx, result in enumerate(results):
-        LOGGER.info(
-            "Rollout %s reward %.3f contradictions %s", idx, result.reward, result.contradiction_report
-        )
+        LOGGER.info("Completed %s rollouts", len(results))
+        for idx, result in enumerate(results):
+            LOGGER.info(
+                "Rollout %s reward %.3f contradictions %s",
+                idx,
+                result.reward,
+                result.contradiction_report,
+            )
 
-    LOGGER.info("Adversarial scenarios available: %s", list(iterate_adversarial_pool()))
+        _write_rollout_log(log_dir, results)
+        LOGGER.info("Rollout summaries written to %s", log_dir.joinpath("rollouts.jsonl"))
+
+        LOGGER.info("Adversarial scenarios available: %s", list(iterate_adversarial_pool()))
+    finally:
+        root_logger.removeHandler(file_handler)
+        file_handler.close()
 
 
 if __name__ == "__main__":

--- a/gepa_mindfulness/training/configs.py
+++ b/gepa_mindfulness/training/configs.py
@@ -1,11 +1,12 @@
 """Configuration models for the training pipeline."""
+
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field, validator
 import yaml
+from pydantic import BaseModel, Field, validator
 
 
 class RewardWeightsConfig(BaseModel):

--- a/gepa_mindfulness/training/reporting.py
+++ b/gepa_mindfulness/training/reporting.py
@@ -1,4 +1,5 @@
 """Utilities for rendering training summaries with Jinja2 templates."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -35,6 +36,8 @@ def render_summary(results: Iterable[RolloutResult]) -> SummaryReport:
 
 def describe_reward(signal: RewardSignal) -> str:
     return (
-        f"Task={signal.task_success:.3f}, GEPA={signal.gepa_score:.3f}, Honesty={signal.honesty_reward:.3f}, "
-        f"Hallucination={signal.hallucination_score:.3f}, Imperative={signal.imperatives_truth.resolve():.3f}"
+        f"Task={signal.task_success:.3f}, GEPA={signal.gepa_score:.3f}, "
+        f"Honesty={signal.honesty_reward:.3f}, "
+        f"Hallucination={signal.hallucination_score:.3f}, "
+        f"Imperative={signal.imperatives_truth.resolve():.3f}"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ target-version = ["py310"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+extend-exclude = ["notebooks"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]

--- a/scripts/labels_import.py
+++ b/scripts/labels_import.py
@@ -25,7 +25,11 @@ def main() -> None:
 
     labels_path = Path(args.labels)
     out_dir = Path(args.out_dir)
-    rows = [json.loads(line) for line in labels_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    rows = [
+        json.loads(line)
+        for line in labels_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     buckets = partition_labels(rows)
 
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/train_classifier.py
+++ b/scripts/train_classifier.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from mindful_trace_gepa.scoring.classifier import Tier2Classifier, load_classifier_from_config
+from mindful_trace_gepa.scoring.classifier import load_classifier_from_config
 
 
 def load_labels(path: Path) -> List[Dict[str, Any]]:

--- a/src/mindful_trace_gepa/__init__.py
+++ b/src/mindful_trace_gepa/__init__.py
@@ -1,10 +1,15 @@
 """Mindful Trace GEPA extensions."""
+
 from __future__ import annotations
 
+from typing import Callable, Optional
+
 try:  # pragma: no cover - defensive import for optional deps
-    from .cli import main as cli_main
+    from .cli import main as _cli_main
 except Exception:  # pragma: no cover
-    cli_main = None
+    cli_main: Optional[Callable[[list[str] | None], None]] = None
+else:
+    cli_main = _cli_main
 
 __all__ = ["cli_main", "main"]
 
@@ -13,4 +18,4 @@ def main() -> None:
     """Entry point for ``python -m mindful_trace_gepa``."""
     if cli_main is None:  # pragma: no cover - defensive
         raise RuntimeError("CLI entrypoint unavailable; optional dependencies not installed")
-    cli_main()
+    cli_main(None)

--- a/src/mindful_trace_gepa/__main__.py
+++ b/src/mindful_trace_gepa/__main__.py
@@ -1,4 +1,5 @@
 """Module entry point for Mindful Trace GEPA CLI."""
+
 from __future__ import annotations
 
 from .cli import main

--- a/src/mindful_trace_gepa/cli_scoring.py
+++ b/src/mindful_trace_gepa/cli_scoring.py
@@ -1,28 +1,26 @@
 """CLI helpers for the automated wisdom scoring pipeline."""
+
 from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional
-
-try:  # pragma: no cover - optional dependency
-    import yaml
-except ModuleNotFoundError:  # pragma: no cover
-    yaml = None
+from typing import Any, Dict, List, Mapping, Optional
 
 from .scoring import (
     LLMJudge,
     aggregate_tiers,
+    build_config,
     load_classifier_from_config,
     run_heuristics,
     write_scoring_artifacts,
 )
-from .scoring.aggregate import DEFAULT_CONFIG
 from .scoring.llm_judge import JudgeConfig
 from .scoring.schema import AggregateScores, TierScores
 from .storage import iter_jsonl
+from .utils.imports import optional_import
+
+yaml = optional_import("yaml")
 
 
 def _load_yaml(path: Path) -> Dict[str, Any]:
@@ -37,29 +35,13 @@ def _load_yaml(path: Path) -> Dict[str, Any]:
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
-def _clone_default_config() -> Dict[str, Any]:
-    cloned: Dict[str, Any] = {}
-    for key, value in DEFAULT_CONFIG.items():
-        if isinstance(value, Mapping):
-            cloned[key] = dict(value)
-        else:
-            cloned[key] = value
-    return cloned
-
-
 def _load_scoring_config(path: Path | None) -> Dict[str, Any]:
-    base = _clone_default_config()
     if path is None:
-        return base
+        return build_config()
     data = _load_yaml(path)
-    for key, value in data.items():
-        if isinstance(value, Mapping) and isinstance(base.get(key), Mapping):
-            merged = dict(base[key])
-            merged.update(value)
-            base[key] = merged
-        else:
-            base[key] = value
-    return base
+    if not isinstance(data, Mapping):
+        return build_config()
+    return build_config(data)
 
 
 def _load_trace_events(path: Path) -> List[Dict[str, Any]]:
@@ -92,7 +74,11 @@ def handle_score_auto(args: argparse.Namespace) -> None:
 
     classifier_scores: Optional[TierScores] = None
     if getattr(args, "classifier", False):
-        classifier_config_path = getattr(args, "classifier_config", "configs/classifier/default.yml")
+        classifier_config_path = getattr(
+            args,
+            "classifier_config",
+            "configs/classifier/default.yml",
+        )
         classifier = load_classifier_from_config(classifier_config_path)
         artifacts_path = getattr(args, "classifier_artifacts", "artifacts/classifier")
         try:
@@ -122,7 +108,7 @@ def handle_judge_run(args: argparse.Namespace) -> None:
     events = _load_trace_events(trace_path)
     judge = LLMJudge(JudgeConfig(model=args.model or "gpt-sim-judge", mock=args.mock))
     tier = judge.score_trace(events)
-    payload = tier.dict()
+    payload = tier.to_dict()
     Path(args.out).write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
@@ -131,7 +117,11 @@ def handle_classifier_train(args: argparse.Namespace) -> None:
     config_path = Path(args.config)
     out_path = Path(args.out)
 
-    rows = [json.loads(line) for line in labels_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    rows = [
+        json.loads(line)
+        for line in labels_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     classifier = load_classifier_from_config(config_path)
     classifier.fit(rows)
     out_path.mkdir(parents=True, exist_ok=True)
@@ -155,11 +145,13 @@ def handle_lowconf_triage(args: argparse.Namespace) -> None:
     rows: List[Dict[str, Any]] = []
     for dim, conf in aggregate.confidence.items():
         if conf < args.threshold:
-            rows.append({
-                "dimension": dim,
-                "confidence": conf,
-                "score": aggregate.final.get(dim),
-            })
+            rows.append(
+                {
+                    "dimension": dim,
+                    "confidence": conf,
+                    "score": aggregate.final.get(dim),
+                }
+            )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
 
@@ -174,7 +166,12 @@ def register_cli(subparsers: argparse._SubParsersAction) -> None:
     scoring.add_argument("--classifier", action="store_true", help="Include classifier tier")
     scoring.add_argument("--classifier-config", help="Classifier config YAML")
     scoring.add_argument("--classifier-artifacts", help="Directory with trained classifier")
-    scoring.add_argument("--no-print", action="store_false", dest="print", help="Suppress stdout summary")
+    scoring.add_argument(
+        "--no-print",
+        action="store_false",
+        dest="print",
+        help="Suppress stdout summary",
+    )
     scoring.set_defaults(func=handle_score_auto)
 
     judge = subparsers.add_parser("judge", help="Interact with the tiered judge")

--- a/src/mindful_trace_gepa/configuration.py
+++ b/src/mindful_trace_gepa/configuration.py
@@ -1,4 +1,5 @@
 """Configuration helpers for Mindful Trace GEPA."""
+
 from __future__ import annotations
 
 import json
@@ -6,10 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict
 
-try:  # pragma: no cover - optional dependency
-    import yaml  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - fallback parser
-    yaml = None  # type: ignore
+from .utils.imports import optional_import
+
+yaml = optional_import("yaml")
 
 DEFAULT_DSPY_CONFIG_PATH = Path("policies/dspy.yml")
 

--- a/src/mindful_trace_gepa/deception/score.py
+++ b/src/mindful_trace_gepa/deception/score.py
@@ -1,4 +1,5 @@
 """Aggregate deception scoring based on detector signals."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable

--- a/src/mindful_trace_gepa/deception/signals.py
+++ b/src/mindful_trace_gepa/deception/signals.py
@@ -1,9 +1,10 @@
 """Signal detectors for deception baselines."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from difflib import SequenceMatcher
-from typing import Iterable, List, Mapping
+from typing import Iterable, List
 
 REWARD_HACKING_LEXICON = {
     "reward hack",
@@ -26,7 +27,9 @@ class DivergenceResult:
     reasons: List[str]
 
 
-def semantic_divergence(public_answer: str, honest_chain: str, deceptive_chain: str) -> DivergenceResult:
+def semantic_divergence(
+    public_answer: str, honest_chain: str, deceptive_chain: str
+) -> DivergenceResult:
     matcher_public_honest = SequenceMatcher(None, public_answer.lower(), honest_chain.lower())
     matcher_public_deceptive = SequenceMatcher(None, public_answer.lower(), deceptive_chain.lower())
     honest_ratio = matcher_public_honest.ratio()
@@ -35,7 +38,8 @@ def semantic_divergence(public_answer: str, honest_chain: str, deceptive_chain: 
     reasons = []
     if score > 0.1:
         reasons.append(
-            f"Public answer matches deceptive chain more closely ({deceptive_ratio:.2f}) than honest ({honest_ratio:.2f})."
+            "Public answer matches deceptive chain more closely "
+            f"({deceptive_ratio:.2f}) than honest ({honest_ratio:.2f})."
         )
     elif honest_ratio < 0.6:
         reasons.append("Public answer drifts from honest chain, potential omission.")

--- a/src/mindful_trace_gepa/dspy_modules/__init__.py
+++ b/src/mindful_trace_gepa/dspy_modules/__init__.py
@@ -1,7 +1,7 @@
 """DSPy module exports for Mindful Trace GEPA."""
 
-from .pipeline import GEPAChain
 from .compile import DSPyCompiler
+from .pipeline import GEPAChain
 from .signatures import ALL_SIGNATURES
 
 __all__ = ["GEPAChain", "DSPyCompiler", "ALL_SIGNATURES"]

--- a/src/mindful_trace_gepa/dspy_modules/compile.py
+++ b/src/mindful_trace_gepa/dspy_modules/compile.py
@@ -1,4 +1,5 @@
 """Guarded prompt compilation utilities for the pseudo-DSPy pipeline."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -6,9 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
 
 from ..configuration import DSPyConfig, dump_json, load_dspy_config
-from .pipeline import GEPAChain
 from .signatures import ALL_SIGNATURES
-
 
 DEFAULT_PROMPTS: Dict[str, str] = {
     signature.name: (
@@ -50,9 +49,15 @@ class DSPyCompiler:
         auto-tuning.
         """
 
-        allow_opt = self.config.allow_optimizations if enable_optimizations is None else enable_optimizations
+        allow_opt = (
+            self.config.allow_optimizations
+            if enable_optimizations is None
+            else enable_optimizations
+        )
         if allow_opt and not self.config.enabled:
-            raise RuntimeError("Cannot optimise DSPy modules while the feature is disabled by policy.")
+            raise RuntimeError(
+                "Cannot optimise DSPy modules while the feature is disabled by policy."
+            )
 
         prompts = dict(DEFAULT_PROMPTS)
         if allow_opt:
@@ -95,7 +100,8 @@ class DSPyCompiler:
                     raise ValueError(f"Prompt for {name} contains forbidden phrase: {phrase}")
             if not REQUIRED_INVARIANTS.issubset(set(prompt.split())):
                 raise ValueError(
-                    f"Prompt for {name} removed a required invariant token. Present words: {sorted(set(prompt.split()))}"
+                    "Prompt for {name} removed a required invariant token. Present words: "
+                    f"{sorted(set(prompt.split()))}"
                 )
 
 

--- a/src/mindful_trace_gepa/dspy_modules/pipeline.py
+++ b/src/mindful_trace_gepa/dspy_modules/pipeline.py
@@ -1,12 +1,12 @@
 """Declarative pipeline that mimics DSPy behaviour for GEPA tracing."""
+
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+from typing import Any, Dict, List, Mapping, MutableMapping
 
-from gepa_mindfulness.core.tracing import SelfTracingLogger
+from gepa_mindfulness.core.tracing import SelfTracingLogger, ThoughtTrace
 
 from ..configuration import DSPyConfig, load_dspy_config
 from .signatures import (
@@ -21,7 +21,6 @@ from .signatures import (
     SignatureCallable,
     Tensions,
 )
-
 
 TRACE_STAGE_BY_SIGNATURE: Mapping[str, str] = {
     Framing.name: "framing",
@@ -91,7 +90,10 @@ class GEPAChain:
                 return f"Mindful decision: choose the option that upholds GEPA values. {options}"
             if signature is Safeguards:
                 decision = inputs.get("decision", "")
-                return f"Safeguards: double-check honesty, abstain if uncertain. Derived from {decision}."
+                return (
+                    "Safeguards: double-check honesty, abstain if uncertain. "
+                    f"Derived from {decision}."
+                )
             if signature is Reflection:
                 return f"Reflection on trajectory: {history}"
             return f"Unhandled signature {signature.name}"
@@ -121,6 +123,7 @@ class GEPAChain:
         principle_scores: Dict[str, float] = {}
         imperative_scores: Dict[str, float] = {}
 
+        trace: ThoughtTrace
         with self.tracer.trace(chain="dspy") as trace:
             for signature in ALL_SIGNATURES:
                 callable_ = self._callable_for(signature)
@@ -151,7 +154,7 @@ class GEPAChain:
                     }
                 )
 
-        summary = trace.summary() if trace else {}
+        summary = trace.summary()
         final_answer = inputs.get(Decision.output_field, summary.get("decision", ""))
         principle_scores = self._mock_principle_scores(summary)
         imperative_scores = self._mock_imperative_scores(summary)
@@ -176,7 +179,11 @@ class GEPAChain:
         return scores or {"framing": 0.0}
 
     def _mock_imperative_scores(self, summary: Mapping[str, str]) -> Dict[str, float]:
-        imperatives = {"Reduce Suffering": 0.8, "Increase Prosperity": 0.7, "Increase Knowledge": 0.9}
+        imperatives = {
+            "Reduce Suffering": 0.8,
+            "Increase Prosperity": 0.7,
+            "Increase Knowledge": 0.9,
+        }
         if "safeguards" in summary:
             imperatives["Reduce Suffering"] = min(1.0, imperatives["Reduce Suffering"] + 0.1)
         if "decision" in summary and "abstain" in summary["decision"].lower():

--- a/src/mindful_trace_gepa/dspy_modules/signatures.py
+++ b/src/mindful_trace_gepa/dspy_modules/signatures.py
@@ -1,4 +1,5 @@
 """Typed signatures used by the declarative DSPy-like pipeline."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mindful_trace_gepa/emitters/paired_chains.py
+++ b/src/mindful_trace_gepa/emitters/paired_chains.py
@@ -1,4 +1,5 @@
 """Emitter that produces paired honest and deceptive chains for baselining."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping

--- a/src/mindful_trace_gepa/scoring/__init__.py
+++ b/src/mindful_trace_gepa/scoring/__init__.py
@@ -1,10 +1,11 @@
 """Tiered scoring pipeline for Mindful Trace GEPA."""
+
+from .aggregate import DEFAULT_CONFIG, aggregate_tiers, build_config
+from .classifier import Tier2Classifier, load_classifier_from_config
+from .export import write_scoring_artifacts
+from .llm_judge import LLMJudge
 from .schema import AggregateScores, JudgeOutput, TierScores
 from .tier0_heuristics import run_heuristics
-from .llm_judge import LLMJudge
-from .classifier import Tier2Classifier, load_classifier_from_config
-from .aggregate import aggregate_tiers
-from .export import write_scoring_artifacts
 
 __all__ = [
     "AggregateScores",
@@ -15,5 +16,7 @@ __all__ = [
     "Tier2Classifier",
     "load_classifier_from_config",
     "aggregate_tiers",
+    "build_config",
+    "DEFAULT_CONFIG",
     "write_scoring_artifacts",
 ]

--- a/src/mindful_trace_gepa/scoring/classifier.py
+++ b/src/mindful_trace_gepa/scoring/classifier.py
@@ -1,4 +1,5 @@
 """Tier-2 calibrated classifier built on lightweight, dependency-free heads."""
+
 from __future__ import annotations
 
 import json
@@ -9,13 +10,11 @@ from pathlib import Path
 from statistics import mean
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
-try:  # pragma: no cover - optional dependency
-    import yaml
-except ModuleNotFoundError:  # pragma: no cover
-    yaml = None
-
+from ..utils.imports import optional_import
 from .schema import DIMENSIONS, TierScores
 from .tier0_heuristics import _normalise_events, run_heuristics
+
+yaml = optional_import("yaml")
 
 
 @dataclass
@@ -60,7 +59,9 @@ class Tier2Classifier:
     # ------------------------------------------------------------------
     # Feature extraction
     # ------------------------------------------------------------------
-    def _extract_feature_vector(self, trace_text: str, heuristic_meta: Optional[TierScores] = None) -> List[float]:
+    def _extract_feature_vector(
+        self, trace_text: str, heuristic_meta: Optional[TierScores] = None
+    ) -> List[float]:
         trace_lower = trace_text.lower()
         keyword_pairs = {
             "uncertainty": trace_lower.count("uncertainty") + trace_lower.count("confidence"),
@@ -133,7 +134,9 @@ class Tier2Classifier:
             "baseline": self.baseline,
         }
         (path / "model.json").write_text(json.dumps(model_blob, indent=2), encoding="utf-8")
-        (path / "calibration.json").write_text(json.dumps(self.temperature, indent=2), encoding="utf-8")
+        (path / "calibration.json").write_text(
+            json.dumps(self.temperature, indent=2), encoding="utf-8"
+        )
 
     def load(self, directory: str | os.PathLike[str]) -> None:
         path = Path(directory)
@@ -143,9 +146,15 @@ class Tier2Classifier:
             raise FileNotFoundError(f"Classifier weights not found at {model_path}")
         blob = json.loads(model_path.read_text(encoding="utf-8"))
         self.settings = ClassifierSettings(
-            include_heuristic_features=bool(blob.get("settings", {}).get("include_heuristic_features", True)),
-            include_length_feature=bool(blob.get("settings", {}).get("include_length_feature", True)),
-            calibration_strategy=str(blob.get("settings", {}).get("calibration_strategy", "temperature")),
+            include_heuristic_features=bool(
+                blob.get("settings", {}).get("include_heuristic_features", True)
+            ),
+            include_length_feature=bool(
+                blob.get("settings", {}).get("include_length_feature", True)
+            ),
+            calibration_strategy=str(
+                blob.get("settings", {}).get("calibration_strategy", "temperature")
+            ),
         )
         self.feature_names = list(blob.get("settings", {}).get("feature_names", []))
         self.bias = {dim: float(value) for dim, value in blob.get("bias", {}).items()}
@@ -167,7 +176,9 @@ class Tier2Classifier:
             return TierScores(
                 tier="classifier",
                 scores=dict(heuristic_meta.scores),
-                confidence={dim: max(0.05, min(1.0, heuristic_meta.confidence[dim])) for dim in DIMENSIONS},
+                confidence={
+                    dim: max(0.05, min(1.0, heuristic_meta.confidence[dim])) for dim in DIMENSIONS
+                },
                 meta={"fallback": "heuristic"},
             )
         scores: Dict[str, int] = {}

--- a/src/mindful_trace_gepa/scoring/export.py
+++ b/src/mindful_trace_gepa/scoring/export.py
@@ -1,4 +1,5 @@
 """Export helpers for scoring pipeline artifacts."""
+
 from __future__ import annotations
 
 import json

--- a/src/mindful_trace_gepa/scoring/llm_judge.py
+++ b/src/mindful_trace_gepa/scoring/llm_judge.py
@@ -1,4 +1,5 @@
 """Tier-1 LLM judge orchestration."""
+
 from __future__ import annotations
 
 import json
@@ -35,8 +36,12 @@ class LLMJudge:
         self.config = config or JudgeConfig()
         if os.getenv("GEPA_JUDGE_MOCK") == "1":
             self.config.mock = True
-        self.prompt_template = PROMPT_PATH.read_text(encoding="utf-8") if PROMPT_PATH.exists() else ""
-        self.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8")) if SCHEMA_PATH.exists() else {}
+        self.prompt_template = (
+            PROMPT_PATH.read_text(encoding="utf-8") if PROMPT_PATH.exists() else ""
+        )
+        self.schema = (
+            json.loads(SCHEMA_PATH.read_text(encoding="utf-8")) if SCHEMA_PATH.exists() else {}
+        )
 
     def score_trace(self, trace_events: Any) -> TierScores:
         trace_text = _normalise_events(trace_events)

--- a/src/mindful_trace_gepa/scoring/schema.py
+++ b/src/mindful_trace_gepa/scoring/schema.py
@@ -1,9 +1,9 @@
 """Data models for the tiered wisdom scoring pipeline without external deps."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Literal, Mapping
-
+from typing import Any, Dict, List, Literal, Mapping
 
 DIMENSIONS = ["mindfulness", "compassion", "integrity", "prudence"]
 ALLOWED_TIERS = {"heuristic", "judge", "classifier"}
@@ -80,12 +80,13 @@ class JudgeOutput:
     def to_tier_scores(self, confidence_floor: float = 0.1) -> "TierScores":
         scores = {dim: getattr(self, dim).score for dim in DIMENSIONS}
         confidence = {
-            dim: max(confidence_floor, 1.0 - getattr(self, dim).uncertainty)
-            for dim in DIMENSIONS
+            dim: max(confidence_floor, 1.0 - getattr(self, dim).uncertainty) for dim in DIMENSIONS
         }
         meta = {
             "rationales": {dim: getattr(self, dim).rationale for dim in DIMENSIONS},
-            "spans": {dim: [span.to_dict() for span in getattr(self, dim).spans] for dim in DIMENSIONS},
+            "spans": {
+                dim: [span.to_dict() for span in getattr(self, dim).spans] for dim in DIMENSIONS
+            },
             "abstain": self.abstain,
         }
         return TierScores(tier="judge", scores=scores, confidence=confidence, meta=meta)

--- a/src/mindful_trace_gepa/scoring/tier0_heuristics.py
+++ b/src/mindful_trace_gepa/scoring/tier0_heuristics.py
@@ -1,11 +1,11 @@
 """Tier-0 deterministic heuristics for wisdom dimensions."""
+
 from __future__ import annotations
 
 import re
 from typing import Any, Dict, Iterable, List, Sequence
 
 from .schema import DIMENSIONS, TierScores
-
 
 UNCERTAINTY_PATTERNS = [
     r"\bconfidence\b",

--- a/src/mindful_trace_gepa/storage/jsonl_store.py
+++ b/src/mindful_trace_gepa/storage/jsonl_store.py
@@ -1,21 +1,21 @@
 """JSONL storage utilities supporting streaming and sharding."""
+
 from __future__ import annotations
 
+import hashlib
 import io
 import json
-import hashlib
 import logging
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, List, Optional
 
+from ..utils.imports import optional_import
+
 LOGGER = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
-    import zstandard as zstd  # type: ignore
-except Exception:  # pragma: no cover
-    zstd = None  # type: ignore
+zstd = optional_import("zstandard")
 
 
 def _open_text(path: Path) -> io.TextIOBase:

--- a/src/mindful_trace_gepa/tokens.py
+++ b/src/mindful_trace_gepa/tokens.py
@@ -1,9 +1,10 @@
 """Utilities for capturing token-level metadata."""
+
 from __future__ import annotations
 
 import json
 import math
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List, Sequence
@@ -79,9 +80,9 @@ class TokenRecorder:
 
     def extend(self, other: Iterable[TokenRecord]) -> None:
         for record in other:
-            record.idx = len(self.records)  # type: ignore[attr-defined]
-            self.records.append(record)
-            inferred_global = record.chunk * self.sample_every + record.offset + 1
+            normalized = replace(record, idx=len(self.records))
+            self.records.append(normalized)
+            inferred_global = normalized.chunk * self.sample_every + normalized.offset + 1
             self._global_idx = max(self._global_idx, inferred_global)
 
     def dump_jsonl(self, path: Path) -> None:

--- a/src/mindful_trace_gepa/train/__init__.py
+++ b/src/mindful_trace_gepa/train/__init__.py
@@ -1,5 +1,5 @@
 """Training utilities for Mindful Trace GEPA."""
 
-from .dist import get_accelerator, wrap_model_optimizer, save_sharded
+from .dist import get_accelerator, save_sharded, wrap_model_optimizer
 
 __all__ = ["get_accelerator", "wrap_model_optimizer", "save_sharded"]

--- a/src/mindful_trace_gepa/utils/imports.py
+++ b/src/mindful_trace_gepa/utils/imports.py
@@ -1,0 +1,25 @@
+"""Helpers for importing optional dependencies safely."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Optional
+
+
+def optional_import(name: str) -> Optional[ModuleType]:
+    """Attempt to import *name*, returning ``None`` if unavailable."""
+
+    try:
+        module = import_module(name)
+    except ModuleNotFoundError:
+        return None
+    except Exception:
+        # Some optional dependencies raise custom errors during import when
+        # system libraries are missing (e.g. Cairo for WeasyPrint). Treat
+        # those the same as an unavailable module.
+        return None
+    return module
+
+
+__all__ = ["optional_import"]

--- a/src/mindful_trace_gepa/utils/longctx/select_spans.py
+++ b/src/mindful_trace_gepa/utils/longctx/select_spans.py
@@ -1,11 +1,11 @@
 """Utilities for selecting long-context spans via lightweight retrieval."""
+
 from __future__ import annotations
 
 import math
 import re
 from dataclasses import dataclass
 from typing import Iterable, List, Sequence
-
 
 _TOKEN_RE = re.compile(r"\w+")
 
@@ -21,12 +21,14 @@ class Span:
     embedding: Sequence[float] | None = None
 
 
-def _bm25_score(query_tokens: Sequence[str], doc_tokens: Sequence[str], idf: dict[str, float], avg_len: float) -> float:
+def _bm25_score(
+    query_tokens: Sequence[str], doc_tokens: Sequence[str], idf: dict[str, float], avg_len: float
+) -> float:
     k1 = 1.5
     b = 0.75
     score = 0.0
     doc_len = len(doc_tokens) or 1
-    tf = {}
+    tf: dict[str, int] = {}
     for token in doc_tokens:
         tf[token] = tf.get(token, 0) + 1
     for token in query_tokens:
@@ -83,7 +85,8 @@ def select_top_spans(
     k:
         Number of spans to return.
     method:
-        Retrieval scoring method. ``"bm25"`` (default) or ``"cosine"`` for embedding cosine similarity.
+        Retrieval scoring method. ``"bm25"`` (default) or ``"cosine"``
+        for embedding cosine similarity.
     query_embedding:
         Optional embedding vector for the query when using cosine similarity.
     """

--- a/src/mindful_trace_gepa/viewer/builder.py
+++ b/src/mindful_trace_gepa/viewer/builder.py
@@ -1,10 +1,10 @@
 """Offline trace viewer builder."""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
-
+from typing import Any, Dict, List
 
 VIEWER_DIR = Path(__file__).resolve().parent
 

--- a/src/mindful_trace_gepa/wrappers/openai_wrapper.py
+++ b/src/mindful_trace_gepa/wrappers/openai_wrapper.py
@@ -1,8 +1,8 @@
 """Simplified OpenAI wrapper with optional log-prob capture."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
 
 from ..tokens import TokenRecord, TokenRecorder
 

--- a/src/mindful_trace_gepa/wrappers/vllm_wrapper.py
+++ b/src/mindful_trace_gepa/wrappers/vllm_wrapper.py
@@ -1,4 +1,5 @@
 """Simplified vLLM wrapper with optional log-prob capture."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-  
+
 SRC = ROOT / "src"
 if SRC.exists() and str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/test_aggregate_confidence.py
+++ b/tests/test_aggregate_confidence.py
@@ -1,4 +1,4 @@
-from mindful_trace_gepa.scoring.aggregate import aggregate_tiers
+from mindful_trace_gepa.scoring.aggregate import DEFAULT_CONFIG, aggregate_tiers, build_config
 from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
 
 
@@ -12,24 +12,30 @@ def test_aggregation_escalates_on_disagreement():
     heuristic = make_tier("heuristic", 2, 0.7)
     judge = make_tier("judge", 4, 0.9)
     classifier = make_tier("classifier", 0, 0.8)
-    result = aggregate_tiers([heuristic, judge, classifier], {
-        "weights": {"heuristic": 0.2, "judge": 0.5, "classifier": 0.3},
-        "abstention_thresholds": {dim: 0.75 for dim in DIMENSIONS},
-        "disagreement_penalty": 0.2,
-        "escalate_if_any_below": 0.6,
-    })
+    result = aggregate_tiers(
+        [heuristic, judge, classifier],
+        {
+            "weights": {"heuristic": 0.2, "judge": 0.5, "classifier": 0.3},
+            "abstention_thresholds": {dim: 0.75 for dim in DIMENSIONS},
+            "disagreement_penalty": 0.2,
+            "escalate_if_any_below": 0.6,
+        },
+    )
     assert result.escalate is True
     assert any("disagreement" in reason for reason in result.reasons)
 
 
 def test_aggregation_escalates_on_low_confidence():
     heuristic = make_tier("heuristic", 2, 0.2)
-    result = aggregate_tiers([heuristic], {
-        "weights": {"heuristic": 1.0},
-        "abstention_thresholds": {dim: 0.5 for dim in DIMENSIONS},
-        "disagreement_penalty": 0.0,
-        "escalate_if_any_below": 0.4,
-    })
+    result = aggregate_tiers(
+        [heuristic],
+        {
+            "weights": {"heuristic": 1.0},
+            "abstention_thresholds": {dim: 0.5 for dim in DIMENSIONS},
+            "disagreement_penalty": 0.0,
+            "escalate_if_any_below": 0.4,
+        },
+    )
     assert result.escalate is True
     assert any("below" in reason for reason in result.reasons)
 
@@ -38,7 +44,32 @@ def test_partial_weight_override_preserves_defaults():
     heuristic = make_tier("heuristic", 0, 1.0)
     judge = make_tier("judge", 4, 1.0)
     classifier = make_tier("classifier", 2, 1.0)
-    result = aggregate_tiers([heuristic, judge, classifier], {
-        "weights": {"judge": 0.7},
-    })
+    result = aggregate_tiers(
+        [heuristic, judge, classifier],
+        {
+            "weights": {"judge": 0.7},
+        },
+    )
     assert result.final["mindfulness"] == 3
+
+
+def test_build_config_sanitizes_numeric_values():
+    config = build_config(
+        {
+            "weights": {"judge": "0.4", "classifier": None},
+            "abstention_thresholds": {"mindfulness": "0.8", "integrity": None},
+            "disagreement_penalty": "0.5",
+            "escalate_if_any_below": None,
+        }
+    )
+
+    assert config["weights"]["judge"] == 0.4
+    # Classifier weight should retain default 0.3 because override was None
+    assert config["weights"]["classifier"] == DEFAULT_CONFIG["weights"]["classifier"]
+    assert config["abstention_thresholds"]["mindfulness"] == 0.8
+    # Purpose threshold fallback should remain default value
+    expected_integrity = DEFAULT_CONFIG["abstention_thresholds"]["integrity"]
+    assert config["abstention_thresholds"]["integrity"] == expected_integrity
+    # Numeric fields should coerce to float and ignore None override
+    assert config["disagreement_penalty"] == 0.5
+    assert config["escalate_if_any_below"] == DEFAULT_CONFIG["escalate_if_any_below"]

--- a/tests/test_cli_score_auto.py
+++ b/tests/test_cli_score_auto.py
@@ -1,10 +1,8 @@
-import json
-import json
 import argparse
-import os
-from pathlib import Path
+import json
 
 from mindful_trace_gepa.cli_scoring import handle_score_auto
+from mindful_trace_gepa.scoring import DEFAULT_CONFIG, build_config
 from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
 
 
@@ -12,7 +10,10 @@ def test_score_auto_generates_output(tmp_path, monkeypatch):
     trace_path = tmp_path / "trace.jsonl"
     events = [
         {
-            "content": "We assume 30% uptake with monitoring; stakeholders include users and regulators.",
+            "content": (
+                "We assume 30% uptake with monitoring; stakeholders include users "
+                "and regulators."
+            ),
             "gepa_hits": ["monitor"],
         },
         {
@@ -82,3 +83,85 @@ def test_score_auto_partial_weights_merge(tmp_path, monkeypatch):
     handle_score_auto(args)
     payload = json.loads(out_path.read_text(encoding="utf-8"))
     assert payload["final"]["mindfulness"] == 3
+
+
+def test_score_auto_none_classifier_weight_uses_default(tmp_path, monkeypatch):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(json.dumps({"content": "placeholder"}), encoding="utf-8")
+
+    config_path = tmp_path / "weights.yml"
+    config_path.write_text("weights:\n  judge: 0.4\n  classifier: null\n", encoding="utf-8")
+
+    def fake_run_heuristics(events):
+        scores = {dim: 4 for dim in DIMENSIONS}
+        confidence = {dim: 1.0 for dim in DIMENSIONS}
+        return TierScores(tier="heuristic", scores=scores, confidence=confidence, meta={})
+
+    class DummyJudge:
+        def __init__(self, config) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def score_trace(self, events):
+            scores = {dim: 2 for dim in DIMENSIONS}
+            confidence = {dim: 1.0 for dim in DIMENSIONS}
+            return TierScores(tier="judge", scores=scores, confidence=confidence, meta={})
+
+    class DummyClassifier:
+        def __init__(self, config) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def load(self, path):  # pragma: no cover - stub does nothing
+            return None
+
+        def predict(self, events):
+            scores = {dim: 4 for dim in DIMENSIONS}
+            confidence = {dim: 1.0 for dim in DIMENSIONS}
+            return TierScores(tier="classifier", scores=scores, confidence=confidence, meta={})
+
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.run_heuristics", fake_run_heuristics)
+    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.LLMJudge", DummyJudge)
+
+    def load_dummy_classifier(path):
+        return DummyClassifier(path)
+
+    monkeypatch.setattr(
+        "mindful_trace_gepa.cli_scoring.load_classifier_from_config",
+        load_dummy_classifier,
+    )
+
+    out_path = tmp_path / "scores.json"
+
+    args = argparse.Namespace(
+        trace=str(trace_path),
+        policy=None,
+        out=str(out_path),
+        config=str(config_path),
+        judge=True,
+        classifier=True,
+        classifier_config="unused",
+        classifier_artifacts=str(tmp_path / "artifacts"),
+        print=False,
+    )
+
+    handle_score_auto(args)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["final"]["mindfulness"] == 3
+
+
+def test_build_config_sanitizes_numeric_values():
+    config = build_config(
+        {
+            "weights": {"judge": "0.4", "classifier": None},
+            "abstention_thresholds": {"mindfulness": "0.8", "integrity": None},
+            "disagreement_penalty": "0.5",
+            "escalate_if_any_below": None,
+        }
+    )
+
+    assert config["weights"]["judge"] == 0.4
+    assert config["weights"]["classifier"] == DEFAULT_CONFIG["weights"]["classifier"]
+    assert config["abstention_thresholds"]["mindfulness"] == 0.8
+    expected_integrity = DEFAULT_CONFIG["abstention_thresholds"]["integrity"]
+    assert config["abstention_thresholds"]["integrity"] == expected_integrity
+    assert config["disagreement_penalty"] == 0.5
+    assert config["escalate_if_any_below"] == DEFAULT_CONFIG["escalate_if_any_below"]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from mindful_trace_gepa.deception.signals import (
-    REWARD_HACKING_LEXICON,
     SITUATIONAL_AWARENESS_MARKERS,
     confidence_inversion,
     lexicon_hits,

--- a/tests/test_dspy_disabled.py
+++ b/tests/test_dspy_disabled.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 from mindful_trace_gepa.cli import handle_dspy_run
 from mindful_trace_gepa.configuration import load_dspy_config

--- a/tests/test_llm_judge_schema.py
+++ b/tests/test_llm_judge_schema.py
@@ -1,4 +1,4 @@
-from mindful_trace_gepa.scoring.llm_judge import LLMJudge, JudgeConfig
+from mindful_trace_gepa.scoring.llm_judge import JudgeConfig, LLMJudge
 from mindful_trace_gepa.scoring.schema import DIMENSIONS
 
 
@@ -14,5 +14,3 @@ def test_mock_judge_matches_schema(monkeypatch):
         spans = tier.meta["spans"][dim]
         assert isinstance(spans, list)
         assert spans[0]["start"] == 0
-
-

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -22,25 +22,31 @@ class FloatLike:
     def __str__(self) -> str:
         return str(float(self._value))
 
+
 def test_aggregate_gepa_score_basic_weighting():
     sessions = [
-        PracticeSession(duration_minutes=30, grounding=0.6, equanimity=0.5, purpose=0.8, awareness=0.7),
-        PracticeSession(duration_minutes=15, grounding=0.9, equanimity=0.8, purpose=0.9, awareness=0.85),
+        PracticeSession(
+            duration_minutes=30, grounding=0.6, equanimity=0.5, purpose=0.8, awareness=0.7
+        ),
+        PracticeSession(
+            duration_minutes=15, grounding=0.9, equanimity=0.8, purpose=0.9, awareness=0.85
+        ),
     ]
 
     # expected value computed manually
-    expected = (
-        ((0.6 + 0.5 + 0.8 + 0.7) / 4.0) * 30
-        + ((0.9 + 0.8 + 0.9 + 0.85) / 4.0) * 15
-    ) / 45
+    expected = (((0.6 + 0.5 + 0.8 + 0.7) / 4.0) * 30 + ((0.9 + 0.8 + 0.9 + 0.85) / 4.0) * 15) / 45
 
     assert math.isclose(aggregate_gepa_score(sessions), expected)
 
 
 def test_aggregate_gepa_metrics_reports_per_axis():
     sessions = [
-        PracticeSession(duration_minutes=10, grounding=0.2, equanimity=0.4, purpose=0.6, awareness=0.8),
-        PracticeSession(duration_minutes=20, grounding=0.5, equanimity=0.6, purpose=0.7, awareness=0.4),
+        PracticeSession(
+            duration_minutes=10, grounding=0.2, equanimity=0.4, purpose=0.6, awareness=0.8
+        ),
+        PracticeSession(
+            duration_minutes=20, grounding=0.5, equanimity=0.6, purpose=0.7, awareness=0.4
+        ),
     ]
 
     result = aggregate_gepa_metrics(sessions)
@@ -49,7 +55,9 @@ def test_aggregate_gepa_metrics_reports_per_axis():
     expected_equanimity = (0.4 * 10 + 0.6 * 20) / 30
     expected_purpose = (0.6 * 10 + 0.7 * 20) / 30
     expected_awareness = (0.8 * 10 + 0.4 * 20) / 30
-    expected_gepa = (expected_grounding + expected_equanimity + expected_purpose + expected_awareness) / 4
+    expected_gepa = (
+        expected_grounding + expected_equanimity + expected_purpose + expected_awareness
+    ) / 4
 
     assert isinstance(result, AggregateResult)
     assert math.isclose(result.total_duration, 30)
@@ -60,10 +68,15 @@ def test_aggregate_gepa_metrics_reports_per_axis():
     assert math.isclose(aggregate_gepa_score(sessions), result.gepa)
     assert math.isclose(result.gepa, expected_gepa)
 
+
 def test_zero_duration_sessions_are_ignored():
     sessions = [
-        PracticeSession(duration_minutes=0, grounding=0.4, equanimity=0.5, purpose=0.6, awareness=0.7),
-        PracticeSession(duration_minutes=0, grounding=0.9, equanimity=0.9, purpose=0.9, awareness=0.9),
+        PracticeSession(
+            duration_minutes=0, grounding=0.4, equanimity=0.5, purpose=0.6, awareness=0.7
+        ),
+        PracticeSession(
+            duration_minutes=0, grounding=0.9, equanimity=0.9, purpose=0.9, awareness=0.9
+        ),
     ]
 
     result = aggregate_gepa_metrics(sessions)
@@ -79,10 +92,13 @@ def test_zero_duration_sessions_are_ignored():
 
 
 def test_validation_rejects_out_of_range_scores():
-    session = PracticeSession(duration_minutes=10, grounding=1.5, equanimity=0.5, purpose=0.5, awareness=0.5)
+    session = PracticeSession(
+        duration_minutes=10, grounding=1.5, equanimity=0.5, purpose=0.5, awareness=0.5
+    )
 
     with pytest.raises(ValueError):
         aggregate_gepa_score([session])
+
 
 def test_validation_rejects_high_precision_decimal_out_of_range():
     session = PracticeSession(
@@ -95,6 +111,7 @@ def test_validation_rejects_high_precision_decimal_out_of_range():
 
     with pytest.raises(ValueError, match=r"grounding must be within \[0\.0, 1\.0\]"):
         aggregate_gepa_score([session])
+
 
 def test_validation_rejects_high_precision_fraction_out_of_range():
     huge_denominator = 10**30
@@ -109,11 +126,15 @@ def test_validation_rejects_high_precision_fraction_out_of_range():
     with pytest.raises(ValueError, match=r"grounding must be within \[0\.0, 1\.0\]"):
         aggregate_gepa_score([session])
 
+
 def test_validation_rejects_negative_duration():
-    session = PracticeSession(duration_minutes=-1, grounding=0.5, equanimity=0.5, purpose=0.5, awareness=0.5)
+    session = PracticeSession(
+        duration_minutes=-1, grounding=0.5, equanimity=0.5, purpose=0.5, awareness=0.5
+    )
 
     with pytest.raises(ValueError):
         aggregate_gepa_score([session])
+
 
 def test_validation_rejects_non_finite_duration():
     session = PracticeSession(
@@ -159,6 +180,7 @@ def test_validation_rejects_non_finite_duration():
 
     with pytest.raises(ValueError, match="duration_minutes must be finite"):
         aggregate_gepa_score([session])
+
 
 def test_validation_rejects_underflowing_duration():
     session = PracticeSession(
@@ -218,6 +240,7 @@ def test_validation_rejects_non_finite_axis_scores():
     with pytest.raises(ValueError, match="grounding must be finite"):
         aggregate_gepa_score([session])
 
+
 def test_validation_rejects_underflowing_axis_scores():
     session = PracticeSession(
         duration_minutes=10,
@@ -229,6 +252,7 @@ def test_validation_rejects_underflowing_axis_scores():
 
     with pytest.raises(ValueError, match="grounding is too small"):
         aggregate_gepa_score([session])
+
 
 def test_validation_rejects_non_numeric_inputs():
     with pytest.raises(TypeError, match="duration_minutes must be a real number"):
@@ -274,7 +298,7 @@ def test_validation_rejects_non_numeric_inputs():
 def test_aggregate_gepa_metrics_supports_decimal_and_fraction_inputs():
     sessions = [
         PracticeSession(
-            duration_minutes=Decimal("15"),
+            duration_minutes=Decimal(15),
             grounding=Fraction(1, 2),
             equanimity=Fraction(2, 3),
             purpose=Decimal("0.8"),
@@ -291,7 +315,7 @@ def test_aggregate_gepa_metrics_supports_decimal_and_fraction_inputs():
 
     result = aggregate_gepa_metrics(sessions)
 
-    first_weight = float(Decimal("15"))
+    first_weight = float(Decimal(15))
     second_weight = float(Fraction(45, 2))
     total_duration = first_weight + second_weight
     expected_grounding = (
@@ -313,6 +337,7 @@ def test_aggregate_gepa_metrics_supports_decimal_and_fraction_inputs():
     assert math.isclose(result.purpose, expected_purpose)
     assert math.isclose(result.awareness, expected_awareness)
     assert math.isclose(aggregate_gepa_score(sessions), result.gepa)
+
 
 def test_aggregate_gepa_metrics_accepts_float_like_inputs():
     sessions = [
@@ -425,10 +450,10 @@ def test_aggregate_gepa_metrics_raises_when_duration_underflows_float():
         aggregate_gepa_metrics(sessions)
 
     with pytest.raises(ValueError, match="duration_minutes is too small"):
-      aggregate_gepa_score(sessions)
+        aggregate_gepa_score(sessions)
 
     with pytest.raises(ValueError, match="total duration is too small"):
         aggregate_gepa_metrics(sessions)
 
     with pytest.raises(ValueError, match="total duration is too small"):
-      aggregate_gepa_score(sessions)
+        aggregate_gepa_score(sessions)

--- a/tests/test_tier0_heuristics.py
+++ b/tests/test_tier0_heuristics.py
@@ -5,14 +5,22 @@ from mindful_trace_gepa.scoring.tier0_heuristics import run_heuristics
 def test_heuristics_detect_signals():
     trace = [
         {
-            "content": "We estimate 40% ±5 uncertainty and will monitor telemetry weekly with rollback triggers.",
+            "content": (
+                "We estimate 40% ±5 uncertainty and will monitor telemetry weekly "
+                "with rollback triggers."
+            ),
             "gepa_hits": ["monitor", "rollback"],
         },
         {
-            "content": "Stakeholders include residents, gig workers, and regulators; mitigation includes subsidies and audits.",
+            "content": (
+                "Stakeholders include residents, gig workers, and regulators; "
+                "mitigation includes subsidies and audits."
+            ),
         },
         {
-            "content": "Policy GEPA-12 forbids manipulation; we disclose limitations and audit logs.",
+            "content": (
+                "Policy GEPA-12 forbids manipulation; we disclose limitations and " "audit logs."
+            ),
         },
         {
             "content": "Option A vs Option B with contingency plans and worst-case analysis.",

--- a/tests/test_training_cli.py
+++ b/tests/test_training_cli.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+import types
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+# Provide a lightweight pydantic stub so the training CLI can be imported without
+# the optional dependency installed in the test environment.
+if "pydantic" not in sys.modules:
+    stub = types.ModuleType("pydantic")
+
+    class _StubBaseModel:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        @classmethod
+        def parse_obj(cls, payload):  # type: ignore[override]
+            return cls(**payload)
+
+        def dict(self):  # type: ignore[override]
+            return self.__dict__.copy()
+
+    def _stub_field(*_args, default=None, **_kwargs):
+        return default
+
+    def _stub_validator(*_args, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    stub.BaseModel = _StubBaseModel
+    stub.Field = _stub_field
+    stub.validator = _stub_validator
+    sys.modules["pydantic"] = stub
+
+if "torch" not in sys.modules:
+    torch_stub = types.ModuleType("torch")
+
+    def _stub_device(value):
+        return value
+
+    def _stub_manual_seed(_seed):
+        return None
+
+    def _stub_tensor(values):
+        return values
+
+    torch_stub.device = _stub_device
+    torch_stub.manual_seed = _stub_manual_seed
+    torch_stub.tensor = _stub_tensor
+    sys.modules["torch"] = torch_stub
+
+if "transformers" not in sys.modules:
+    transformers_stub = types.ModuleType("transformers")
+
+    class _AutoModel:
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            return cls()
+
+        def to(self, _device):
+            return self
+
+        def generate(self, **_kwargs):
+            return [[0]]
+
+    class _TokenizerCall(dict):
+        def to(self, _device):
+            return self
+
+    class _AutoTokenizer:
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            return cls()
+
+        def __call__(self, _prompt, **_kwargs):
+            return _TokenizerCall({"input_ids": [[0]]})
+
+        def decode(self, _tokens, **_kwargs):
+            return ""
+
+    transformers_stub.AutoModelForCausalLM = _AutoModel
+    transformers_stub.AutoTokenizer = _AutoTokenizer
+    sys.modules["transformers"] = transformers_stub
+
+if "trl" not in sys.modules:
+    trl_stub = types.ModuleType("trl")
+
+    class _PPOConfig:
+        def __init__(self, **_kwargs):
+            return
+
+    class _PPOTrainer:
+        def __init__(self, **_kwargs):
+            return
+
+        def step(self, *_args, **_kwargs):
+            return None
+
+    trl_stub.PPOConfig = _PPOConfig
+    trl_stub.PPOTrainer = _PPOTrainer
+    sys.modules["trl"] = trl_stub
+
+if "jinja2" not in sys.modules:
+    jinja_stub = types.ModuleType("jinja2")
+
+    class _Template:
+        def __init__(self, *_args, **_kwargs):
+            return
+
+        def render(self, **_kwargs):
+            return ""
+
+    jinja_stub.Template = _Template
+    sys.modules["jinja2"] = jinja_stub
+
+cli = importlib.import_module("gepa_mindfulness.training.cli")
+RolloutResult = importlib.import_module("gepa_mindfulness.training.pipeline").RolloutResult
+
+
+class _StubOrchestrator:
+    def __init__(self, results: list[RolloutResult]):
+        self._results = results
+        self.run_calls: list[list[str]] = []
+        self.adversarial_calls = 0
+
+    def run(self, prompts: list[str]) -> list[RolloutResult]:
+        self.run_calls.append(list(prompts))
+        return self._results
+
+    def run_adversarial_eval(self) -> list[RolloutResult]:
+        self.adversarial_calls += 1
+        return self._results
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> None:
+    root_logger = logging.getLogger()
+    # Remove any file handlers attached by previous tests to avoid side effects.
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+        handler.close()
+
+
+def _write_stub_files(tmp_path: Path) -> tuple[Path, Path]:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("config: value\n", encoding="utf-8")
+    dataset_path = tmp_path / "dataset.txt"
+    dataset_path.write_text("prompt one\n", encoding="utf-8")
+    return config_path, dataset_path
+
+
+def test_training_cli_writes_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path, dataset_path = _write_stub_files(tmp_path)
+    log_dir = tmp_path / "logs"
+
+    results = [
+        RolloutResult(
+            prompt="prompt one",
+            response="response",
+            reward=0.5,
+            trace_summary={"step": 1},
+            contradiction_report={"issues": []},
+        )
+    ]
+    orchestrator = _StubOrchestrator(results)
+
+    monkeypatch.setattr(cli, "load_training_config", lambda _: object())
+    monkeypatch.setattr(cli, "TrainingOrchestrator", lambda config: orchestrator)
+    monkeypatch.setattr(cli, "iterate_adversarial_pool", lambda: [])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gepa-train",
+            "--config",
+            str(config_path),
+            "--dataset",
+            str(dataset_path),
+            "--log-dir",
+            str(log_dir),
+        ],
+    )
+
+    cli.main()
+
+    rollout_log = log_dir / "rollouts.jsonl"
+    training_log = log_dir / "training.log"
+
+    assert rollout_log.exists()
+    assert training_log.exists()
+
+    payloads = [json.loads(line) for line in rollout_log.read_text(encoding="utf-8").splitlines()]
+    assert payloads == [asdict(result) for result in results]
+
+
+def test_training_cli_prompts_for_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path, dataset_path = _write_stub_files(tmp_path)
+    chosen_dir = tmp_path / "prompted"
+
+    results = [
+        RolloutResult(
+            prompt="prompt one",
+            response="response",
+            reward=1.0,
+            trace_summary={},
+            contradiction_report={},
+        )
+    ]
+    orchestrator = _StubOrchestrator(results)
+
+    monkeypatch.setattr(cli, "load_training_config", lambda _: object())
+    monkeypatch.setattr(cli, "TrainingOrchestrator", lambda config: orchestrator)
+    monkeypatch.setattr(cli, "iterate_adversarial_pool", lambda: [])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gepa-train",
+            "--config",
+            str(config_path),
+            "--dataset",
+            str(dataset_path),
+        ],
+    )
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: str(chosen_dir))
+
+    cli.main()
+
+    assert (chosen_dir / "rollouts.jsonl").exists()
+    assert (chosen_dir / "training.log").exists()

--- a/tests/test_viewer_build.py
+++ b/tests/test_viewer_build.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 from mindful_trace_gepa.cli import handle_view
 
@@ -10,7 +10,13 @@ def test_viewer_cli_build(tmp_path: Path) -> None:
     trace_path = tmp_path / "trace.jsonl"
     tokens_path = tmp_path / "tokens.jsonl"
     trace_path.write_text('{"stage": "framing", "content": "hello"}\n', encoding="utf-8")
-    tokens_path.write_text('{"idx": 0, "token": "hello", "logprob": -0.1, "topk": [], "conf": 0.9, "abstained": false, "ts": "2024"}\n', encoding="utf-8")
+    tokens_path.write_text(
+        (
+            '{"idx": 0, "token": "hello", "logprob": -0.1, "topk": [], '
+            '"conf": 0.9, "abstained": false, "ts": "2024"}\n'
+        ),
+        encoding="utf-8",
+    )
     out_path = tmp_path / "report.html"
     args = SimpleNamespace(
         trace=str(trace_path),


### PR DESCRIPTION
## Summary
- add a --log-dir argument to the PPO training CLI, prompting for a location when run interactively and wiring file logging alongside the console output
- persist rollout results to JSONL and attach a file handler so operators can inspect training logs after the run completes
- cover the new behavior with CLI-focused tests that stub optional dependencies and verify both explicit and prompted log destinations

## Testing
- ruff check .
- black --check .
- mypy src/mindful_trace_gepa
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e016c0fd988330941a2f735dd1bd0a