### PR TITLE
Provide default log dir for non-interactive training CLI runs

### DIFF
--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -56,9 +56,12 @@ def parse_args() -> argparse.Namespace:
                 destination = input("Enter log output directory path: ").strip()
             args.log_dir = Path(destination).expanduser()
         else:
-            parser.error("--log-dir is required when standard input is not interactive")
+            default_log_dir = Path.cwd() / "training_logs"
+            args.log_dir = default_log_dir
     else:
         args.log_dir = args.log_dir.expanduser()
+
+    args.log_dir = args.log_dir.expanduser()
 
     return args
 
@@ -165,26 +168,26 @@ def main() -> None:
                 result.contradiction_report,
             )
 
-    rollout_path = log_dir / "rollouts.jsonl"
-    _serialize_rollouts(rollout_path, results)
-    LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
+        rollout_path = log_dir / "rollouts.jsonl"
+        _serialize_rollouts(rollout_path, results)
+        LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
 
-    rollout_path = log_dir / "rollouts.jsonl"
-    _serialize_rollouts(rollout_path, results)
-    LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
+        rollout_path = log_dir / "rollouts.jsonl"
+        _serialize_rollouts(rollout_path, results)
+        LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
 
-    rollout_path = log_dir / "rollouts.jsonl"
-    _serialize_rollouts(rollout_path, results)
-    LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
+        rollout_path = log_dir / "rollouts.jsonl"
+        _serialize_rollouts(rollout_path, results)
+        LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
 
-    LOGGER.info("Completed %s rollouts", len(results))
-    for idx, result in enumerate(results):
-        LOGGER.info(
-            "Rollout %s reward %.3f contradictions %s",
-            idx,
-            result.reward,
-            result.contradiction_report,
-        )
+        LOGGER.info("Completed %s rollouts", len(results))
+        for idx, result in enumerate(results):
+            LOGGER.info(
+                "Rollout %s reward %.3f contradictions %s",
+                idx,
+                result.reward,
+                result.contradiction_report,
+            )
 
         LOGGER.info("Adversarial scenarios available: %s", list(iterate_adversarial_pool()))
     finally:


### PR DESCRIPTION
## Summary
- default the training CLI to write logs under ./training_logs when --log-dir is omitted in non-interactive environments while keeping the interactive prompt for TTY runs
- tidy the CLI serialization block so the logging and roll-out writes stay within the guarded section
- extend the training CLI tests to cover the non-interactive default path and update stubbing to avoid importing the real orchestrator

## Testing
- pytest tests/test_training_cli.py tests/test_training_cli_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e395b95ae08330bcfebe72c5019cda