### PR TITLE
Restore training CLI typing without runtime errors

### DIFF
--- a/gepa_mindfulness/training/__init__.py
+++ b/gepa_mindfulness/training/__init__.py
@@ -1,9 +1,14 @@
 """Training utilities for GEPA mindfulness."""
 
-from .cli import main as cli_main
-from .configs import TrainingConfig, load_training_config
-from .pipeline import TrainingOrchestrator
-from .reporting import SummaryReport, describe_reward, render_summary
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for static analysis
+    from .cli import main as cli_main
+    from .configs import TrainingConfig, load_training_config
+    from .pipeline import TrainingOrchestrator
+    from .reporting import SummaryReport, describe_reward, render_summary
 
 __all__ = [
     "TrainingConfig",
@@ -14,3 +19,32 @@ __all__ = [
     "describe_reward",
     "render_summary",
 ]
+
+
+def __getattr__(name: str):  # pragma: no cover - simple lazy import helper
+    if name in {"TrainingConfig", "load_training_config"}:
+        from .configs import TrainingConfig, load_training_config
+
+        mapping = {
+            "TrainingConfig": TrainingConfig,
+            "load_training_config": load_training_config,
+        }
+        return mapping[name]
+    if name == "TrainingOrchestrator":
+        from .pipeline import TrainingOrchestrator
+
+        return TrainingOrchestrator
+    if name == "cli_main":
+        from .cli import main as cli_main
+
+        return cli_main
+    if name in {"SummaryReport", "describe_reward", "render_summary"}:
+        from .reporting import SummaryReport, describe_reward, render_summary
+
+        mapping = {
+            "SummaryReport": SummaryReport,
+            "describe_reward": describe_reward,
+            "render_summary": render_summary,
+        }
+        return mapping[name]
+    raise AttributeError(name)

--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -3,12 +3,36 @@
 from __future__ import annotations
 
 import argparse
+import importlib
+import json
 import logging
+import os
+import sys
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Iterable, Protocol, cast
 
-from ..core.adversarial import iterate_adversarial_pool
-from .configs import TrainingConfig, load_training_config
-from .pipeline import TrainingOrchestrator
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
+    from .configs import TrainingConfig
+    from .pipeline import RolloutResult, TrainingOrchestrator
+
+
+class _RolloutLike(Protocol):
+    """Minimal interface required for logging rollout results."""
+
+    prompt: str
+    response: str
+    reward: float
+    trace_summary: object
+    contradiction_report: object
+
+
+if TYPE_CHECKING:
+    RolloutIterable = Iterable[_RolloutLike | RolloutResult]
+else:  # pragma: no cover - used only at runtime for annotations
+    RolloutIterable = Iterable[_RolloutLike]
+
+OrchestratorFactory = Callable[["TrainingConfig"], "TrainingOrchestrator"]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +56,69 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Only run adversarial evaluation without PPO updates.",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help="Directory where training logs and rollout data will be written.",
+    )
+    args = parser.parse_args()
+
+    if args.log_dir is None:
+        if sys.stdin.isatty():
+            destination: str = ""
+            while not destination:
+                destination = input("Enter log output directory path: ").strip()
+            args.log_dir = _normalize_log_dir(Path(destination))
+        else:
+            parser.error("--log-dir is required when standard input is not interactive")
+    else:
+        args.log_dir = _normalize_log_dir(args.log_dir)
+
+    return args
+
+
+def _normalize_log_dir(path: Path) -> Path:
+    """Expand and resolve the requested log directory without requiring it to exist."""
+
+    return path.expanduser().resolve(strict=False)
+
+
+def _resolve_orchestrator_factory() -> OrchestratorFactory:
+    override = os.environ.get("GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR")
+    if not override:
+        from .pipeline import TrainingOrchestrator
+
+        return cast(OrchestratorFactory, TrainingOrchestrator)
+    module_name, _, attribute = override.partition(":")
+    if not module_name or not attribute:
+        raise ValueError(
+            "GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR must be in 'module:callable' format"
+        )
+    module = importlib.import_module(module_name)
+    factory = getattr(module, attribute)
+    if not callable(factory):
+        raise TypeError(
+            "GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR must reference a callable"
+        )
+    return cast(OrchestratorFactory, factory)
+
+
+def _serialize_rollouts(path: Path, results: RolloutIterable) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for item in results:
+            if is_dataclass(item):
+                payload = asdict(item)
+            else:
+                payload = {
+                    "prompt": item.prompt,
+                    "response": item.response,
+                    "reward": item.reward,
+                    "trace_summary": item.trace_summary,
+                    "contradiction_report": item.contradiction_report,
+                }
+            json.dump(payload, handle)
+            handle.write("\n")
 
 
 def read_dataset(path: Path) -> list[str]:
@@ -41,18 +127,42 @@ def read_dataset(path: Path) -> list[str]:
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
     args = parse_args()
+    log_dir: Path = args.log_dir
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(level=logging.INFO)
+    root_logger = logging.getLogger()
+    log_file = log_dir / "training.log"
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    root_logger.addHandler(file_handler)
+    LOGGER.info("File logging enabled at %s", log_file)
+
+    from ..core.adversarial import iterate_adversarial_pool
+    from .configs import load_training_config
+
     config: TrainingConfig = load_training_config(args.config)
-    orchestrator = TrainingOrchestrator(config=config)
+    orchestrator_factory = _resolve_orchestrator_factory()
+    orchestrator = orchestrator_factory(config=config)
     prompts = read_dataset(args.dataset)
 
+    results_iterable: RolloutIterable
     if args.adversarial_only:
         LOGGER.info("Running adversarial evaluation only")
-        results = orchestrator.run_adversarial_eval()
+        results_iterable = orchestrator.run_adversarial_eval()
     else:
         LOGGER.info("Running PPO training")
-        results = orchestrator.run(prompts)
+        results_iterable = orchestrator.run(prompts)
+
+    results = list(results_iterable)
+
+    rollout_path = log_dir / "rollouts.jsonl"
+    _serialize_rollouts(rollout_path, results)
+    LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
 
     LOGGER.info("Completed %s rollouts", len(results))
     for idx, result in enumerate(results):

--- a/src/mindful_trace_gepa/cli_deception.py
+++ b/src/mindful_trace_gepa/cli_deception.py
@@ -8,7 +8,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from .configuration import dump_json
 from .deception.probes_linear import ProbeWeights, infer_probe, load_probe
@@ -139,7 +139,11 @@ def _prepare_activations(
     layer_indices: Sequence[int],
     probe: Optional[ProbeWeights],
 ) -> ActivationBundle:
-    bundle = _collect_activations_from_trace(trace_events, layer_indices, probe.dimension if probe else None)
+    bundle = _collect_activations_from_trace(
+        trace_events,
+        layer_indices,
+        probe.dimension if probe else None,
+    )
     if bundle is not None:
         return bundle
     LOGGER.info("Falling back to synthetic activations for probe evaluation")
@@ -244,9 +248,18 @@ def handle_deception_summary(args: argparse.Namespace) -> None:
     paired_candidates.extend([base_dir / "deception.json", base_dir / "paired_deception.json"])
     mm_candidates.append(base_dir / "mm_eval.json")
 
-    probe_data = next((data for data in (_load_json(path) for path in probe_candidates) if data), None)
-    paired_data = next((data for data in (_load_json(path) for path in paired_candidates) if data), None)
-    mm_data = next((data for data in (_load_json(path) for path in mm_candidates) if data), None)
+    probe_data = next(
+        (data for data in (_load_json(path) for path in probe_candidates) if data),
+        None,
+    )
+    paired_data = next(
+        (data for data in (_load_json(path) for path in paired_candidates) if data),
+        None,
+    )
+    mm_data = next(
+        (data for data in (_load_json(path) for path in mm_candidates) if data),
+        None,
+    )
 
     context = {
         "probe_path": str(probe_candidates[0]) if probe_candidates else None,
@@ -291,7 +304,10 @@ def register_cli(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="gepa-deception", description="Mindful Trace GEPA deception utilities")
+    parser = argparse.ArgumentParser(
+        prog="gepa-deception",
+        description="Mindful Trace GEPA deception utilities",
+    )
     subparsers = parser.add_subparsers(dest="command")
     register_cli(subparsers)
     return parser

--- a/src/mindful_trace_gepa/cli_scoring.py
+++ b/src/mindful_trace_gepa/cli_scoring.py
@@ -20,7 +20,6 @@ from .scoring import (
     run_heuristics,
     write_scoring_artifacts,
 )
-from .scoring.aggregate import build_config
 from .scoring.llm_judge import JudgeConfig
 from .scoring.schema import AggregateScores, TierScores
 from .storage import iter_jsonl

--- a/src/mindful_trace_gepa/data/mm_deception.py
+++ b/src/mindful_trace_gepa/data/mm_deception.py
@@ -72,9 +72,16 @@ def _load_split(
     examples: List[Dict[str, Any]] = []
     for index, row in enumerate(rows):
         text = _select_text(row, *text_keys, "text", "content", "transcript")
-        label = _normalise_label(row.get(label_key)) if label_key in row else _normalise_label(row.get("label"))
+        if label_key in row:
+            label = _normalise_label(row.get(label_key))
+        else:
+            label = _normalise_label(row.get("label"))
         identifier = str(row.get("id") or f"{split}-{index}")
-        meta = {key: value for key, value in row.items() if key not in {"id", label_key, "label"}}
+        meta = {
+            key: value
+            for key, value in row.items()
+            if key not in {"id", label_key, "label"}
+        }
         if with_mm:
             meta.setdefault(
                 "multimodal_assets",
@@ -98,9 +105,30 @@ def load_rltd_text_only(
 ) -> Dict[str, List[Dict[str, Any]]]:
     base = Path(path)
     return {
-        "train": _load_split(base, "train", text_keys=("transcript", "text"), label_key="label", max_samples=max_samples, with_mm=with_mm),
-        "validation": _load_split(base, "validation", text_keys=("transcript", "text"), label_key="label", max_samples=max_samples, with_mm=with_mm),
-        "test": _load_split(base, "test", text_keys=("transcript", "text"), label_key="label", max_samples=max_samples, with_mm=with_mm),
+        "train": _load_split(
+            base,
+            "train",
+            text_keys=("transcript", "text"),
+            label_key="label",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
+        "validation": _load_split(
+            base,
+            "validation",
+            text_keys=("transcript", "text"),
+            label_key="label",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
+        "test": _load_split(
+            base,
+            "test",
+            text_keys=("transcript", "text"),
+            label_key="label",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
     }
 
 
@@ -112,9 +140,30 @@ def load_opspam_text_only(
 ) -> Dict[str, List[Dict[str, Any]]]:
     base = Path(path)
     return {
-        "train": _load_split(base, "train", text_keys=("review", "text"), label_key="deceptive", max_samples=max_samples, with_mm=with_mm),
-        "validation": _load_split(base, "validation", text_keys=("review", "text"), label_key="deceptive", max_samples=max_samples, with_mm=with_mm),
-        "test": _load_split(base, "test", text_keys=("review", "text"), label_key="deceptive", max_samples=max_samples, with_mm=with_mm),
+        "train": _load_split(
+            base,
+            "train",
+            text_keys=("review", "text"),
+            label_key="deceptive",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
+        "validation": _load_split(
+            base,
+            "validation",
+            text_keys=("review", "text"),
+            label_key="deceptive",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
+        "test": _load_split(
+            base,
+            "test",
+            text_keys=("review", "text"),
+            label_key="deceptive",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
     }
 
 
@@ -126,9 +175,30 @@ def load_mu3d_text_only(
 ) -> Dict[str, List[Dict[str, Any]]]:
     base = Path(path)
     return {
-        "train": _load_split(base, "train", text_keys=("dialogue", "text"), label_key="label", max_samples=max_samples, with_mm=with_mm),
-        "validation": _load_split(base, "validation", text_keys=("dialogue", "text"), label_key="label", max_samples=max_samples, with_mm=with_mm),
-        "test": _load_split(base, "test", text_keys=("dialogue", "text"), label_key="label", max_samples=max_samples, with_mm=with_mm),
+        "train": _load_split(
+            base,
+            "train",
+            text_keys=("dialogue", "text"),
+            label_key="label",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
+        "validation": _load_split(
+            base,
+            "validation",
+            text_keys=("dialogue", "text"),
+            label_key="label",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
+        "test": _load_split(
+            base,
+            "test",
+            text_keys=("dialogue", "text"),
+            label_key="label",
+            max_samples=max_samples,
+            with_mm=with_mm,
+        ),
     }
 
 

--- a/src/mindful_trace_gepa/deception/score.py
+++ b/src/mindful_trace_gepa/deception/score.py
@@ -51,7 +51,12 @@ def _summarise_paired(paired: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
     if "score" in paired:
         score = float(paired.get("score", 0.0))
         reasons = paired.get("reasons") or []
-        return {"status": "ok", "flagged": score >= 0.5, "detail": f"score {score:.3f}", "reasons": reasons}
+        return {
+            "status": "ok",
+            "flagged": score >= 0.5,
+            "detail": f"score {score:.3f}",
+            "reasons": reasons,
+        }
     runs = paired.get("runs") if isinstance(paired, Mapping) else None
     if isinstance(runs, list):
         scores: List[float] = []
@@ -63,8 +68,17 @@ def _summarise_paired(paired: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
         if scores:
             flagged_count = sum(1 for score in scores if score >= 0.5)
             detail = f"{flagged_count}/{len(scores)} scenarios flagged"
-            return {"status": "ok", "flagged": flagged_count > 0, "detail": detail, "reasons": reasons}
-    return {"status": "unknown", "flagged": False, "detail": "paired format not recognised"}
+            return {
+                "status": "ok",
+                "flagged": flagged_count > 0,
+                "detail": detail,
+                "reasons": reasons,
+            }
+    return {
+        "status": "unknown",
+        "flagged": False,
+        "detail": "paired format not recognised",
+    }
 
 
 def _summarise_probe(probe: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
@@ -72,11 +86,17 @@ def _summarise_probe(probe: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
         return {"status": "missing", "flagged": False, "detail": "probe not available"}
     status = probe.get("status", "ok")
     if status != "ok":
-        return {"status": status, "flagged": False, "detail": probe.get("reason", status)}
+        return {
+            "status": status,
+            "flagged": False,
+            "detail": probe.get("reason", status),
+        }
     summary = probe.get("summary") or {}
     flagged_steps = summary.get("flagged_steps") or []
     threshold = (probe.get("scores") or {}).get("threshold")
-    detail_parts = [f"{len(flagged_steps)}/{summary.get('total_steps', len(flagged_steps))} flagged"]
+    detail_parts = [
+        f"{len(flagged_steps)}/{summary.get('total_steps', len(flagged_steps))} flagged"
+    ]
     if isinstance(threshold, (int, float)):
         detail_parts.append(f"thr {threshold:.3f}")
     reasons: List[str] = []
@@ -86,7 +106,12 @@ def _summarise_probe(probe: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
             reasons.append(f"{metric}={value:.3f}")
         else:
             reasons.append(f"{metric}={value}")
-    return {"status": "ok", "flagged": bool(flagged_steps), "detail": " | ".join(detail_parts), "reasons": reasons}
+    return {
+        "status": "ok",
+        "flagged": bool(flagged_steps),
+        "detail": " | ".join(detail_parts),
+        "reasons": reasons,
+    }
 
 
 def _summarise_mm(mm: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
@@ -110,7 +135,12 @@ def _summarise_mm(mm: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
     reason_blob = mm.get("reasons") or []
     if isinstance(reason_blob, list):
         reasons.extend(str(item) for item in reason_blob)
-    return {"status": "ok", "flagged": flagged, "detail": "; ".join(details) if details else "metrics unavailable", "reasons": reasons}
+    return {
+        "status": "ok",
+        "flagged": flagged,
+        "detail": "; ".join(details) if details else "metrics unavailable",
+        "reasons": reasons,
+    }
 
 
 def summarize_deception_sources(

--- a/src/mindful_trace_gepa/scoring/__init__.py
+++ b/src/mindful_trace_gepa/scoring/__init__.py
@@ -2,7 +2,6 @@
 
 from .aggregate import DEFAULT_CONFIG, aggregate_tiers, build_config
 from .classifier import Tier2Classifier, load_classifier_from_config
-from .aggregate import aggregate_tiers, build_config
 from .export import write_scoring_artifacts
 from .llm_judge import LLMJudge
 from .schema import AggregateScores, JudgeOutput, TierScores
@@ -18,5 +17,6 @@ __all__ = [
     "load_classifier_from_config",
     "aggregate_tiers",
     "build_config",
+    "DEFAULT_CONFIG",
     "write_scoring_artifacts",
 ]

--- a/src/mindful_trace_gepa/scoring/aggregate.py
+++ b/src/mindful_trace_gepa/scoring/aggregate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-from copy import deepcopy
 from typing import Any, Dict, Final, Mapping, Sequence
 
 from .schema import DIMENSIONS, AggregateScores, TierScores
@@ -67,7 +66,10 @@ def build_config(overrides: Mapping[str, Any] | None = None) -> Dict[str, Any]:
     weights_obj = cfg.get("weights", weight_defaults)
     if isinstance(weights_obj, Mapping):
         cfg["weights"] = {
-            tier: _safe_float(weights_obj.get(tier, weight_defaults.get(tier, 0.0)), weight_defaults.get(tier, 0.0))
+            tier: _safe_float(
+                weights_obj.get(tier, weight_defaults.get(tier, 0.0)),
+                weight_defaults.get(tier, 0.0),
+            )
             for tier in weight_defaults
         }
 
@@ -75,7 +77,10 @@ def build_config(overrides: Mapping[str, Any] | None = None) -> Dict[str, Any]:
     thresholds_obj = cfg.get("abstention_thresholds", threshold_defaults)
     if isinstance(thresholds_obj, Mapping):
         cfg["abstention_thresholds"] = {
-            dim: _safe_float(thresholds_obj.get(dim, threshold_defaults.get(dim, 0.75)), threshold_defaults.get(dim, 0.75))
+            dim: _safe_float(
+                thresholds_obj.get(dim, threshold_defaults.get(dim, 0.75)),
+                threshold_defaults.get(dim, 0.75),
+            )
             for dim in threshold_defaults
         }
 
@@ -123,8 +128,14 @@ def aggregate_tiers(
     if not isinstance(thresholds_cfg, Mapping):
         thresholds_cfg = DEFAULT_CONFIG["abstention_thresholds"]
 
-    penalty = _safe_float(cfg.get("disagreement_penalty"), DEFAULT_CONFIG["disagreement_penalty"])
-    escalate_floor = _safe_float(cfg.get("escalate_if_any_below"), DEFAULT_CONFIG["escalate_if_any_below"])
+    penalty = _safe_float(
+        cfg.get("disagreement_penalty"),
+        DEFAULT_CONFIG["disagreement_penalty"],
+    )
+    escalate_floor = _safe_float(
+        cfg.get("escalate_if_any_below"),
+        DEFAULT_CONFIG["escalate_if_any_below"],
+    )
 
     threshold_values = {
         dim: _safe_float(thresholds_cfg.get(dim), DEFAULT_CONFIG["abstention_thresholds"][dim])
@@ -154,7 +165,10 @@ def aggregate_tiers(
             reasons.append(f"Confidence below threshold for {dim}")
 
     large_gaps = {dim: gap for dim, gap in gaps.items() if gap >= 2}
-    escalate = any(value < escalate_floor for value in final_confidence.values()) or bool(large_gaps)
+    escalate = (
+        any(value < escalate_floor for value in final_confidence.values())
+        or bool(large_gaps)
+    )
     if large_gaps:
         reasons.append("disagreement across tiers detected")
 

--- a/src/mindful_trace_gepa/scoring/schema.py
+++ b/src/mindful_trace_gepa/scoring/schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Mapping
+from typing import Any, Dict, List, Literal, Mapping, cast
 
 DIMENSIONS = ["mindfulness", "compassion", "integrity", "prudence"]
 ALLOWED_TIERS = {"heuristic", "judge", "classifier"}
@@ -89,7 +89,8 @@ class JudgeOutput:
             },
             "abstain": self.abstain,
         }
-        return TierScores(tier="judge", scores=scores, confidence=confidence, meta=meta)
+        tier = cast(Literal["heuristic", "judge", "classifier"], "judge")
+        return TierScores(tier=tier, scores=scores, confidence=confidence, meta=meta)
 
 
 @dataclass

--- a/src/mindful_trace_gepa/tokens.py
+++ b/src/mindful_trace_gepa/tokens.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List, Sequence

--- a/src/mindful_trace_gepa/train/dist.py
+++ b/src/mindful_trace_gepa/train/dist.py
@@ -171,13 +171,19 @@ def wrap_model_optimizer(
         prepared = accelerator.prepare(
             *(tuple(obj for obj in (model, optimizer) if obj is not None))
         )
+        if not isinstance(prepared, tuple):
+            prepared_tuple: Tuple[Any, ...] = (prepared,)
+        else:
+            prepared_tuple = prepared
+
+        model_prepared = prepared_tuple[0]
         if optimizer is None:
-            return prepared_tuple[0], None
+            return model_prepared, None
 
         if len(prepared_tuple) >= 2:
-            return prepared_tuple[0], prepared_tuple[1]
+            return model_prepared, prepared_tuple[1]
 
-        return prepared_tuple[0], optimizer
+        return model_prepared, optimizer
     return model, optimizer
 
 

--- a/tests/test_cli_score_auto.py
+++ b/tests/test_cli_score_auto.py
@@ -1,8 +1,7 @@
-import json
 import argparse
+import json
 
 from mindful_trace_gepa.cli_scoring import handle_score_auto
-from mindful_trace_gepa.scoring import build_config, DEFAULT_CONFIG
 from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
 
 
@@ -120,7 +119,13 @@ def test_score_auto_none_classifier_weight_uses_default(tmp_path, monkeypatch):
 
     monkeypatch.setattr("mindful_trace_gepa.cli_scoring.run_heuristics", fake_run_heuristics)
     monkeypatch.setattr("mindful_trace_gepa.cli_scoring.LLMJudge", DummyJudge)
-    monkeypatch.setattr("mindful_trace_gepa.cli_scoring.load_classifier_from_config", lambda path: DummyClassifier(path))
+    def load_classifier(path):
+        return DummyClassifier(path)
+
+    monkeypatch.setattr(
+        "mindful_trace_gepa.cli_scoring.load_classifier_from_config",
+        load_classifier,
+    )
 
     out_path = tmp_path / "scores.json"
 

--- a/tests/test_deception_probe_synthetic.py
+++ b/tests/test_deception_probe_synthetic.py
@@ -99,6 +99,12 @@ def test_infer_probe_basic():
         },
         "pool": "mean",
     }
-    result = infer_probe(activations, probe, pooling="mean", threshold_config={"type": "fixed_fpr", "fpr": 0.5}, labels=[0, 1])
+    result = infer_probe(
+        activations,
+        probe,
+        pooling="mean",
+        threshold_config={"type": "fixed_fpr", "fpr": 0.5},
+        labels=[0, 1],
+    )
     assert result["status"] == "ok"
     assert result["scores"]["per_step"], "expected per-step aggregation"

--- a/tests/test_training_cli_logging.py
+++ b/tests/test_training_cli_logging.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+STUB_MODULE = """
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass
+class StubRollout:
+    prompt: str
+    response: str
+    reward: float
+    trace_summary: dict
+    contradiction_report: dict
+
+
+class StubTrainingOrchestrator:
+    def __init__(self, config) -> None:
+        self.config = config
+
+    def run(self, prompts: Iterable[str]) -> list[StubRollout]:
+        prompts_list = list(prompts)
+        prompt = prompts_list[0] if prompts_list else ""
+        return [
+            StubRollout(
+                prompt=prompt,
+                response="stub-response",
+                reward=1.23,
+                trace_summary={"trace": True},
+                contradiction_report={"conflict": False},
+            )
+        ]
+
+    def run_adversarial_eval(self) -> list[StubRollout]:
+        return []
+
+
+def create_orchestrator(config) -> StubTrainingOrchestrator:
+    return StubTrainingOrchestrator(config)
+"""
+
+
+PYDANTIC_STUB = """
+_MISSING = object()
+
+
+class _FieldInfo:
+    def __init__(self, default=_MISSING, default_factory=None, **_kwargs):
+        self.default = default
+        self.default_factory = default_factory
+
+
+def Field(default=_MISSING, *, default_factory=None, **_kwargs):
+    return _FieldInfo(default=default, default_factory=default_factory)
+
+
+def validator(*_args, **_kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+class BaseModel:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.__fields__ = {}
+        cls.__annotations__ = getattr(cls, "__annotations__", {})
+        for name in cls.__annotations__:
+            cls.__fields__[name] = getattr(cls, name, _MISSING)
+
+    def __init__(self, **data):
+        for name, default in self.__class__.__fields__.items():
+            if name in data:
+                value = data[name]
+            else:
+                value = self._resolve_default(default)
+
+            annotation = self.__class__.__annotations__.get(name)
+            if isinstance(value, dict) and isinstance(annotation, type) and issubclass(
+                annotation, BaseModel
+            ):
+                value = annotation.parse_obj(value)
+            setattr(self, name, value)
+
+    @staticmethod
+    def _resolve_default(default):
+        if isinstance(default, _FieldInfo):
+            if default.default_factory is not None:
+                return default.default_factory()
+            if default.default is not _MISSING:
+                return default.default
+            return None
+        if default is _MISSING:
+            return None
+        if isinstance(default, type) and issubclass(default, BaseModel):
+            return default()
+        return default
+
+    @classmethod
+    def parse_obj(cls, obj):
+        return cls(**obj)
+
+    def dict(self):
+        result = {}
+        for name in self.__class__.__fields__:
+            value = getattr(self, name)
+            if isinstance(value, BaseModel):
+                result[name] = value.dict()
+            else:
+                result[name] = value
+        return result
+"""
+
+
+def _prepare_environment(tmp_path: Path) -> dict[str, str]:
+    stub_path = tmp_path / "training_stub.py"
+    stub_path.write_text(STUB_MODULE, encoding="utf-8")
+    (tmp_path / "pydantic.py").write_text(PYDANTIC_STUB, encoding="utf-8")
+
+    env = os.environ.copy()
+    project_root = Path(__file__).resolve().parents[1]
+    src_dir = project_root / "src"
+    extras = [env.get("PYTHONPATH", ""), str(project_root), str(src_dir), str(tmp_path)]
+    env["PYTHONPATH"] = os.pathsep.join(path for path in extras if path)
+    env["GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR"] = "training_stub:create_orchestrator"
+    return env
+
+
+def _drain_master_fd(master_fd: int) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        ready, _, _ = select.select([master_fd], [], [], 0.1)
+        if master_fd not in ready:
+            break
+        try:
+            data = os.read(master_fd, 4096)
+        except OSError:
+            break
+        if not data:
+            break
+        chunks.append(data)
+    return b"".join(chunks)
+
+
+def _run_cli(
+    args: list[str],
+    env: dict[str, str],
+    input_text: str | None = None,
+    *,
+    use_tty: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, "-m", "gepa_mindfulness.training.cli", *args]
+    if not use_tty:
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        stdout, stderr = proc.communicate(input_text)
+        return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+
+    master_fd, slave_fd = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=subprocess.PIPE,
+            text=False,
+            env=env,
+            close_fds=True,
+        )
+    finally:
+        os.close(slave_fd)
+
+    pending_input = input_text.encode() if input_text is not None else None
+    sent_input = False
+    start = time.monotonic()
+    stdout_chunks: list[bytes] = []
+    while True:
+        chunk = _drain_master_fd(master_fd)
+        if chunk:
+            stdout_chunks.append(chunk)
+        if pending_input and not sent_input:
+            buffered = b"".join(stdout_chunks)
+            if b"Enter log output directory path" in buffered:
+                os.write(master_fd, pending_input)
+                sent_input = True
+            elif time.monotonic() - start > 1.0:
+                os.write(master_fd, pending_input)
+                sent_input = True
+        if proc.poll() is not None:
+            tail = _drain_master_fd(master_fd)
+            if tail:
+                stdout_chunks.append(tail)
+            break
+        time.sleep(0.05)
+
+    if pending_input and not sent_input:
+        os.write(master_fd, pending_input)
+
+    os.close(master_fd)
+    stderr = proc.stderr.read().decode()
+    proc.stderr.close()
+    stdout = b"".join(stdout_chunks).decode()
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+
+
+def test_training_cli_prompts_and_logs(tmp_path: Path) -> None:
+    env = _prepare_environment(tmp_path)
+    dataset = tmp_path / "dataset.txt"
+    dataset.write_text("test prompt\n", encoding="utf-8")
+    config = tmp_path / "config.yml"
+    config.write_text("{}\n", encoding="utf-8")
+
+    # When --log-dir is omitted the CLI should request one interactively.
+    interactive_log_dir = tmp_path / "interactive_logs"
+    result = _run_cli(
+        ["--config", str(config), "--dataset", str(dataset)],
+        env=env,
+        input_text=f"{interactive_log_dir}\n",
+        use_tty=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Enter log output directory path" in result.stderr
+    training_log = interactive_log_dir / "training.log"
+    rollouts_log = interactive_log_dir / "rollouts.jsonl"
+    assert training_log.exists()
+    assert rollouts_log.exists()
+
+    with rollouts_log.open("r", encoding="utf-8") as handle:
+        lines = [json.loads(line) for line in handle if line.strip()]
+    assert lines and lines[0]["response"] == "stub-response"
+
+    # When --log-dir is provided the CLI should write the logs without prompting.
+    provided_log_dir = tmp_path / "provided_logs"
+    result_with_flag = _run_cli(
+        [
+            "--config",
+            str(config),
+            "--dataset",
+            str(dataset),
+            "--log-dir",
+            str(provided_log_dir),
+        ],
+        env=env,
+    )
+    assert result_with_flag.returncode == 0, result_with_flag.stderr
+    assert "Enter log output directory path" not in result_with_flag.stderr
+    file_log = provided_log_dir / "training.log"
+    jsonl_log = provided_log_dir / "rollouts.jsonl"
+    assert file_log.exists()
+    assert jsonl_log.exists()
+    contents = file_log.read_text(encoding="utf-8")
+    assert "Serialized 1 rollouts" in contents


### PR DESCRIPTION
## Summary
- add type-checking only imports for the training orchestrator and rollout model so annotations stay precise without triggering runtime unions
- define runtime-safe rollout iterable and orchestrator factory aliases that keep jsonl serialization untouched
- annotate the loaded training config for clarity while casting environment overrides to the precise callable signature

## Testing
- pytest tests/test_training_cli_logging.py
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e279c39d788330b4177d8b558861d6