### PR TITLE
Refactor training CLI orchestration helpers

### DIFF
--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -10,18 +10,20 @@ import os
 import sys
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import Callable, Iterable, TYPE_CHECKING
+from typing import Callable, Iterable, Sequence, TYPE_CHECKING
 
 from ..core.adversarial import iterate_adversarial_pool
 from .configs import TrainingConfig, load_training_config
 
 if TYPE_CHECKING:  # pragma: no cover - import only for type checking
-    from .pipeline import TrainingOrchestrator
+    from .pipeline import RolloutResult, TrainingOrchestrator
 
 LOGGER = logging.getLogger(__name__)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the training CLI."""
+
     parser = argparse.ArgumentParser(description="Run GEPA mindfulness PPO training")
     parser.add_argument(
         "--config",
@@ -46,24 +48,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Directory where training logs and rollout data will be written.",
     )
-    args = parser.parse_args()
-
-    assume_tty = os.environ.get("GEPA_MINDFULNESS_TRAINING_ASSUME_TTY") == "1"
-    if args.log_dir is None:
-        if sys.stdin.isatty() or assume_tty:
-            destination: str = ""
-            while not destination:
-                destination = input("Enter log output directory path: ").strip()
-            args.log_dir = Path(destination).expanduser()
-        else:
-            default_log_dir = Path.cwd() / "training_logs"
-            args.log_dir = default_log_dir
-    else:
-        args.log_dir = args.log_dir.expanduser()
-
-    args.log_dir = args.log_dir.expanduser()
-
-    return args
+    return parser.parse_args(args=list(argv) if argv is not None else None)
 
 
 def _resolve_orchestrator_factory() -> Callable[[TrainingConfig], object]:
@@ -87,6 +72,8 @@ def _resolve_orchestrator_factory() -> Callable[[TrainingConfig], object]:
 
 
 def _serialize_rollouts(path: Path, results: Iterable[object]) -> None:
+    """Persist rollout results as JSON lines."""
+
     with path.open("w", encoding="utf-8") as handle:
         for item in results:
             if is_dataclass(item):
@@ -106,90 +93,112 @@ def _serialize_rollouts(path: Path, results: Iterable[object]) -> None:
 
 
 def read_dataset(path: Path) -> list[str]:
+    """Materialize newline-delimited prompts from *path*."""
+
     with path.open("r", encoding="utf-8") as handle:
         return [line.strip() for line in handle if line.strip()]
 
 
 def _resolve_log_dir(cli_arg: Path | None) -> Path:
+    """Determine the directory to use for logging output."""
+
     if cli_arg is not None:
         return cli_arg.expanduser().resolve()
 
-    if sys.stdin.isatty():
-        destination = input("Enter a directory to store training logs: ").strip()
-        if not destination:
-            raise SystemExit("A log directory is required when running interactively.")
+    assume_tty = os.environ.get("GEPA_MINDFULNESS_TRAINING_ASSUME_TTY") == "1"
+    if sys.stdin.isatty() or assume_tty:
+        destination = ""
+        while not destination:
+            destination = input("Enter a directory to store training logs: ").strip()
         return Path(destination).expanduser().resolve()
 
-    raise SystemExit("--log-dir must be provided when stdin is not interactive.")
+    return (Path.cwd() / "training_logs").resolve()
 
 
-def _write_rollout_log(log_dir: Path, results: list[RolloutResult]) -> None:
-    rollout_path = log_dir / "rollouts.jsonl"
-    with rollout_path.open("w", encoding="utf-8") as handle:
-        for result in results:
-            handle.write(json.dumps(asdict(result), ensure_ascii=False) + "\n")
+def _setup_file_logging(log_dir: Path) -> logging.FileHandler:
+    """Configure logging to write to ``training.log`` within *log_dir*."""
 
-
-def main() -> None:
-    args = parse_args()
-    log_dir: Path = args.log_dir
     log_dir.mkdir(parents=True, exist_ok=True)
 
     logging.basicConfig(level=logging.INFO)
-    root_logger = logging.getLogger()
-    log_file = log_dir / "training.log"
-    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler = logging.FileHandler(log_dir / "training.log", encoding="utf-8")
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(
         logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     )
-    root_logger.addHandler(file_handler)
-    LOGGER.info("File logging enabled at %s", log_file)
+    logging.getLogger().addHandler(file_handler)
+    LOGGER.info("File logging enabled at %s", log_dir / "training.log")
+    return file_handler
 
-    config: TrainingConfig = load_training_config(args.config)
-    orchestrator_factory = _resolve_orchestrator_factory()
-    orchestrator = orchestrator_factory(config=config)
-    prompts = read_dataset(args.dataset)
+
+def _run_orchestrator(
+    orchestrator: "TrainingOrchestrator",
+    prompts: list[str],
+    *,
+    adversarial_only: bool,
+) -> list["RolloutResult"]:
+    """Execute either adversarial evaluation or PPO training."""
+
+    if adversarial_only:
+        LOGGER.info("Running adversarial evaluation only")
+        return orchestrator.run_adversarial_eval()
+
+    LOGGER.info("Running PPO training")
+    return orchestrator.run(prompts)
+
+
+def _log_rollout_summary(results: Iterable["RolloutResult"]) -> None:
+    """Emit a concise summary for each rollout to the logger."""
+
+    for idx, result in enumerate(results):
+        LOGGER.info(
+            "Rollout %s reward %.3f contradictions %s",
+            idx,
+            getattr(result, "reward", None),
+            getattr(result, "contradiction_report", None),
+        )
+
+
+def _serialize_results(log_dir: Path, results: Sequence[object]) -> Path:
+    """Write *results* to ``rollouts.jsonl`` and return the path."""
+
+    rollout_path = log_dir / "rollouts.jsonl"
+    _serialize_rollouts(rollout_path, results)
+    LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
+    return rollout_path
+
+
+def _log_available_adversarial_scenarios() -> None:
+    """Log the identifiers of adversarial scenarios bundled with the package."""
+
+    scenarios = list(iterate_adversarial_pool())
+    LOGGER.info("Adversarial scenarios available: %s", scenarios)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Entrypoint for the command-line training interface."""
+
+    args = parse_args(argv)
+    log_dir = _resolve_log_dir(args.log_dir)
+    file_handler = _setup_file_logging(log_dir)
+    root_logger = logging.getLogger()
 
     try:
-        if args.adversarial_only:
-            LOGGER.info("Running adversarial evaluation only")
-            results = orchestrator.run_adversarial_eval()
-        else:
-            LOGGER.info("Running PPO training")
-            results = orchestrator.run(prompts)
+        config: TrainingConfig = load_training_config(args.config)
+        orchestrator_factory = _resolve_orchestrator_factory()
+        orchestrator = orchestrator_factory(config=config)
+        prompts = read_dataset(args.dataset)
+
+        results = _run_orchestrator(
+            orchestrator,
+            prompts,
+            adversarial_only=args.adversarial_only,
+        )
 
         LOGGER.info("Completed %s rollouts", len(results))
-        for idx, result in enumerate(results):
-            LOGGER.info(
-                "Rollout %s reward %.3f contradictions %s",
-                idx,
-                result.reward,
-                result.contradiction_report,
-            )
-
-        rollout_path = log_dir / "rollouts.jsonl"
-        _serialize_rollouts(rollout_path, results)
-        LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
-
-        rollout_path = log_dir / "rollouts.jsonl"
-        _serialize_rollouts(rollout_path, results)
-        LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
-
-        rollout_path = log_dir / "rollouts.jsonl"
-        _serialize_rollouts(rollout_path, results)
-        LOGGER.info("Serialized %s rollouts to %s", len(results), rollout_path)
-
-        LOGGER.info("Completed %s rollouts", len(results))
-        for idx, result in enumerate(results):
-            LOGGER.info(
-                "Rollout %s reward %.3f contradictions %s",
-                idx,
-                result.reward,
-                result.contradiction_report,
-            )
-
-        LOGGER.info("Adversarial scenarios available: %s", list(iterate_adversarial_pool()))
+        _log_rollout_summary(results)
+        _serialize_results(log_dir, results)
+        _log_available_adversarial_scenarios()
     finally:
         root_logger.removeHandler(file_handler)
         file_handler.close()


### PR DESCRIPTION
## Summary
- restructure the training CLI to parse arguments without side effects and centralize log directory resolution
- add dedicated helpers for configuring logging, executing rollouts, and summarizing results to remove duplicated logic
- ensure rollout serialization and adversarial scenario logging are handled through reusable functions with clear docstrings

## Testing
- python -m compileall gepa_mindfulness/training/cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e3fd1bf568833087f081e023ef8da7