### PR TITLE
Fix lint issues in training CLI and tests

### DIFF
--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -10,7 +10,7 @@ import os
 import sys
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import Callable, Iterable, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence
 
 from ..core.adversarial import iterate_adversarial_pool
 from .configs import TrainingConfig, load_training_config

--- a/tests/test_cli_score_auto.py
+++ b/tests/test_cli_score_auto.py
@@ -2,7 +2,6 @@ import argparse
 import json
 
 from mindful_trace_gepa.cli_scoring import handle_score_auto
-from mindful_trace_gepa.scoring import DEFAULT_CONFIG, build_config
 from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
 
 

--- a/tests/test_training_cli.py
+++ b/tests/test_training_cli.py
@@ -263,7 +263,11 @@ def test_training_cli_uses_default_log_dir_when_non_interactive(
     monkeypatch.setattr(cli, "TrainingOrchestrator", lambda config: orchestrator, raising=False)
     monkeypatch.setattr(cli, "_resolve_orchestrator_factory", lambda: lambda config: orchestrator)
     monkeypatch.setattr(cli, "iterate_adversarial_pool", lambda: [])
-    monkeypatch.setattr(sys, "argv", ["gepa-train", "--config", str(config_path), "--dataset", str(dataset_path)])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["gepa-train", "--config", str(config_path), "--dataset", str(dataset_path)],
+    )
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
     monkeypatch.delenv("GEPA_MINDFULNESS_TRAINING_ASSUME_TTY", raising=False)
 

--- a/tests/test_training_cli_logging.py
+++ b/tests/test_training_cli_logging.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 STUB_MODULE = """
 from dataclasses import dataclass
 from typing import Iterable, List
@@ -133,7 +132,11 @@ def _prepare_environment(tmp_path: Path) -> dict[str, str]:
     return env
 
 
-def _run_cli(args: list[str], env: dict[str, str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+def _run_cli(
+    args: list[str],
+    env: dict[str, str],
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     proc = subprocess.Popen(
         [sys.executable, "-m", "gepa_mindfulness.training.cli", *args],
         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- reorder typing imports in the training CLI module to satisfy Ruff
- remove unused scoring imports from the CLI scoring test
- wrap long argument lists in training CLI tests to respect line length limits

## Testing
- ruff check gepa_mindfulness/training/cli.py tests/test_cli_score_auto.py tests/test_training_cli.py tests/test_training_cli_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e505b42bfc8330ab95f57adf114d42