### PR TITLE
Format code with Black to satisfy linting

### DIFF
--- a/gepa_mindfulness/training/cli.py
+++ b/gepa_mindfulness/training/cli.py
@@ -10,7 +10,7 @@ import os
 import sys
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import Callable, Iterable, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence
 
 from ..core.adversarial import iterate_adversarial_pool
 from .configs import TrainingConfig, load_training_config
@@ -65,9 +65,7 @@ def _resolve_orchestrator_factory() -> Callable[[TrainingConfig], object]:
     module = importlib.import_module(module_name)
     factory = getattr(module, attribute)
     if not callable(factory):
-        raise TypeError(
-            "GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR must reference a callable"
-        )
+        raise TypeError("GEPA_MINDFULNESS_TRAINING_ORCHESTRATOR must reference a callable")
     return factory
 
 
@@ -84,9 +82,7 @@ def _serialize_rollouts(path: Path, results: Iterable[object]) -> None:
                     "response": getattr(item, "response", None),
                     "reward": getattr(item, "reward", None),
                     "trace_summary": getattr(item, "trace_summary", None),
-                    "contradiction_report": getattr(
-                        item, "contradiction_report", None
-                    ),
+                    "contradiction_report": getattr(item, "contradiction_report", None),
                 }
             json.dump(payload, handle)
             handle.write("\n")

--- a/src/mindful_trace_gepa/cli_deception.py
+++ b/src/mindful_trace_gepa/cli_deception.py
@@ -154,11 +154,7 @@ def _collect_labels(trace_events: Sequence[Mapping[str, Any]]) -> Optional[List[
     labels: List[int] = []
     found = False
     for event in trace_events:
-        label = (
-            event.get("deception_label")
-            if isinstance(event, Mapping)
-            else None
-        )
+        label = event.get("deception_label") if isinstance(event, Mapping) else None
         if label is None:
             label = event.get("label") if isinstance(event, Mapping) else None
         if label is None:

--- a/src/mindful_trace_gepa/data/mm_deception.py
+++ b/src/mindful_trace_gepa/data/mm_deception.py
@@ -77,11 +77,7 @@ def _load_split(
         else:
             label = _normalise_label(row.get("label"))
         identifier = str(row.get("id") or f"{split}-{index}")
-        meta = {
-            key: value
-            for key, value in row.items()
-            if key not in {"id", label_key, "label"}
-        }
+        meta = {key: value for key, value in row.items() if key not in {"id", label_key, "label"}}
         if with_mm:
             meta.setdefault(
                 "multimodal_assets",

--- a/src/mindful_trace_gepa/deception/probes_linear.py
+++ b/src/mindful_trace_gepa/deception/probes_linear.py
@@ -70,8 +70,7 @@ def extract_hidden_states(
                 "layers": {
                     str(layer): {
                         "tokens": [
-                            _ensure_float_list(token)
-                            for token in cached_layer.get("tokens", [])
+                            _ensure_float_list(token) for token in cached_layer.get("tokens", [])
                         ],
                         "token_to_step": list(cached_layer.get("token_to_step", [])),
                     }
@@ -156,10 +155,7 @@ def extract_hidden_states(
             return {
                 "layers": {
                     str(key): {
-                        "tokens": [
-                            _ensure_float_list(vec)
-                            for vec in value.get("tokens", [])
-                        ],
+                        "tokens": [_ensure_float_list(vec) for vec in value.get("tokens", [])],
                         "token_to_step": list(value.get("token_to_step", [])),
                     }
                     for key, value in extracted.get("layers", {}).items()
@@ -209,6 +205,7 @@ def load_probe(weights_path: str | Path) -> Optional[ProbeWeights]:
     loader_attempts = [_load_json_weights]
 
     if np is not None:
+
         def _load_numpy(p: Path) -> Optional[ProbeWeights]:
             try:
                 blob = np.load(p, allow_pickle=True)
@@ -234,6 +231,7 @@ def load_probe(weights_path: str | Path) -> Optional[ProbeWeights]:
         loader_attempts.append(_load_numpy)
 
     if torch is not None:
+
         def _load_torch(p: Path) -> Optional[ProbeWeights]:
             try:
                 blob = torch.load(p, map_location="cpu")  # type: ignore[call-arg]
@@ -518,9 +516,7 @@ def infer_probe(
     if metric_labels is not None and metric_scores:
         computed_metrics["auroc"] = auroc(metric_scores, metric_labels)
         computed_metrics["auprc"] = auprc(metric_scores, metric_labels)
-        computed_metrics["fpr_at_tpr80"] = fpr_at_tpr(
-            metric_scores, metric_labels, target_tpr=0.8
-        )
+        computed_metrics["fpr_at_tpr80"] = fpr_at_tpr(metric_scores, metric_labels, target_tpr=0.8)
         if threshold_config and threshold_config.get("type") == "fixed_fpr":
             threshold_value = threshold_at_fpr(
                 metric_scores,

--- a/src/mindful_trace_gepa/scoring/aggregate.py
+++ b/src/mindful_trace_gepa/scoring/aggregate.py
@@ -165,11 +165,9 @@ def aggregate_tiers(
             reasons.append(f"Confidence below threshold for {dim}")
 
     large_gaps = {dim: gap for dim, gap in gaps.items() if gap >= 2}
-    escalate = (
-        any(value < escalate_floor for value in final_confidence.values())
-        or bool(large_gaps)
-    )
+    escalate = any(value < escalate_floor for value in final_confidence.values())
     if large_gaps:
+        escalate = True
         reasons.append("disagreement across tiers detected")
 
     return AggregateScores(

--- a/tests/test_cli_score_auto.py
+++ b/tests/test_cli_score_auto.py
@@ -2,7 +2,6 @@ import argparse
 import json
 
 from mindful_trace_gepa.cli_scoring import handle_score_auto
-from mindful_trace_gepa.scoring import DEFAULT_CONFIG, build_config
 from mindful_trace_gepa.scoring.schema import DIMENSIONS, TierScores
 
 
@@ -120,6 +119,7 @@ def test_score_auto_none_classifier_weight_uses_default(tmp_path, monkeypatch):
 
     monkeypatch.setattr("mindful_trace_gepa.cli_scoring.run_heuristics", fake_run_heuristics)
     monkeypatch.setattr("mindful_trace_gepa.cli_scoring.LLMJudge", DummyJudge)
+
     def load_classifier(path):
         return DummyClassifier(path)
 

--- a/tests/test_training_cli.py
+++ b/tests/test_training_cli.py
@@ -263,7 +263,11 @@ def test_training_cli_uses_default_log_dir_when_non_interactive(
     monkeypatch.setattr(cli, "TrainingOrchestrator", lambda config: orchestrator, raising=False)
     monkeypatch.setattr(cli, "_resolve_orchestrator_factory", lambda: lambda config: orchestrator)
     monkeypatch.setattr(cli, "iterate_adversarial_pool", lambda: [])
-    monkeypatch.setattr(sys, "argv", ["gepa-train", "--config", str(config_path), "--dataset", str(dataset_path)])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["gepa-train", "--config", str(config_path), "--dataset", str(dataset_path)],
+    )
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
     monkeypatch.delenv("GEPA_MINDFULNESS_TRAINING_ASSUME_TTY", raising=False)
 

--- a/tests/test_training_cli_logging.py
+++ b/tests/test_training_cli_logging.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 STUB_MODULE = """
 from dataclasses import dataclass
 from typing import Iterable, List
@@ -133,7 +132,11 @@ def _prepare_environment(tmp_path: Path) -> dict[str, str]:
     return env
 
 
-def _run_cli(args: list[str], env: dict[str, str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+def _run_cli(
+    args: list[str],
+    env: dict[str, str],
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     proc = subprocess.Popen(
         [sys.executable, "-m", "gepa_mindfulness.training.cli", *args],
         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- apply Black formatting to the training CLI serialization helpers
- normalize formatting in deception CLI utilities and dataset loaders
- reflow deception probe utilities and CLI scoring tests to satisfy Black

## Testing
- ruff check gepa_mindfulness/training/cli.py src/mindful_trace_gepa/cli_deception.py src/mindful_trace_gepa/data/mm_deception.py src/mindful_trace_gepa/deception/probes_linear.py src/mindful_trace_gepa/scoring/aggregate.py tests/test_cli_score_auto.py

------
https://chatgpt.com/codex/tasks/task_e_68e505b42bfc8330ab95f57adf114d42