### PR TITLE
Clarify self-tracing availability and notebook paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This repository implements a full training pipeline that integrates GEPA-based
 interpretability, paraconsistent imperative logic, and traceable honesty via
 Anthropic-style thought tracing. The project targets Python 3.10+ and depends on
 `torch`, `transformers`, `trl`, `pydantic`, `jinja2`, `pyyaml`, and
-`self-tracing` (optional).
+`requests`. Optional self-tracing support is provided by the
+[`Self-Tracing`](https://github.com/recursivelabsai/Self-Tracing) project.
+Public packages for that integration are not currently available, so the
+feature remains disabled unless you have been granted access to the upstream
+distribution.
 
 ## Repository Structure
 
@@ -61,11 +65,45 @@ files can be consumed directly or redistributed in packaged form.
 
 ## Getting Started
 
-1. Install dependencies:
+1. Install dependencies (core packages):
 
    ```bash
-   pip install torch transformers trl pydantic jinja2 pyyaml self-tracing requests
+   pip install torch transformers trl pydantic jinja2 pyyaml requests
    ```
+
+   If you have private access to the optional self-tracing package, install it
+   after the core dependencies using the URL provided by the maintainer. If you
+   do not have access, skip the step—the remainder of the project functions
+   without it.
+
+   > **WSL / Debian note:** Recent Debian-based Python builds ship with
+   > `EXTERNALLY-MANAGED` protection, which blocks `pip` from installing packages
+   > into the system interpreter. Create an isolated virtual environment before
+   > installing the requirements:
+   >
+   > ```bash
+   > sudo apt update
+   > sudo apt install python3-venv  # once per machine; installs the matching venv module for your Python 3.x release
+   > python3 -m venv .venv
+   > source .venv/bin/activate
+   > pip install --upgrade pip
+   > pip install torch transformers trl pydantic jinja2 pyyaml requests
+   > # Optional: install the self-tracing package only if you have access to it
+   > ```
+   >
+   > When you are done working, run `deactivate` to exit the environment. Any
+   > project commands (tests, demos, training scripts) should be executed while the
+   > virtual environment is active so they use the isolated interpreter.
+
+   To run the fine-tuning notebooks or any other Jupyter-based workflow, install
+   the notebook tooling inside the same environment (add `--upgrade` if needed):
+
+   ```bash
+   pip install notebook
+   ```
+
+   After installation the `jupyter notebook ...` commands below will be available
+   from the activated virtual environment.
 
 2. Run the CPU example:
 
@@ -159,6 +197,12 @@ minutes. Launch either notebook to reproduce the LoRA workflow:
 jupyter notebook notebooks/ft_phi3_mini_unsloth_gepa.ipynb
 jupyter notebook notebooks/ft_llama3_8b_unsloth_gepa.ipynb
 ```
+
+Run these commands from the repository root (the directory that contains this
+`README.md` file); Jupyter resolves notebook paths relative to the current
+working directory. If you launch the server from another folder (for example,
+`/mnt/c/Users/<name>` on WSL) the notebook path will not be found. Use `pwd` to
+confirm you are inside the cloned repository before invoking `jupyter`.
 
 To launch the notebooks or PPO trainer across multiple GPUs:
 


### PR DESCRIPTION
## Summary
- explain that the optional self-tracing integration currently has no public package and can be skipped without private access
- remind readers to stay inside the repository root when launching Jupyter notebooks so relative paths resolve correctly

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e523035af48330b24202a5cb29cb19