### PR TITLE
Guard tracing optional import fallback

### DIFF
--- a/gepa_mindfulness/core/tracing.py
+++ b/gepa_mindfulness/core/tracing.py
@@ -17,18 +17,23 @@ from typing import (
     cast,
 )
 
+def _local_optional_import(module_name: str):
+    """Gracefully return ``None`` when optional tracing deps are unavailable."""
+
+    import importlib
+
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return None
+
+
 try:  # pragma: no cover - optional dependency missing in most environments
-    from mindful_trace_gepa.utils.imports import optional_import
+    from mindful_trace_gepa.utils.imports import optional_import as _optional_import
 except ModuleNotFoundError:  # pragma: no cover - fallback when package absent
-    def optional_import(module_name: str):
-        """Gracefully return ``None`` when optional tracing deps are unavailable."""
-
-        import importlib
-
-        try:
-            return importlib.import_module(module_name)
-        except ModuleNotFoundError:
-            return None
+    optional_import = _local_optional_import
+else:
+    optional_import = _optional_import
 
 
 class TracerProtocol(Protocol):


### PR DESCRIPTION
## Summary
- add a local optional_import helper in the tracing module
- fall back to the local helper when mindful_trace_gepa is not installed so imports keep working

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68711ee5c8330b81cd13e16e309be