### PR TITLE
Replace thought tracer integration with circuit-tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This repository implements a full training pipeline that integrates GEPA-based
 interpretability, paraconsistent imperative logic, and traceable honesty via
-Anthropic-style thought tracing. The project targets Python 3.10+ and depends on
-`torch`, `transformers`, `trl`, `pydantic`, `jinja2`, `pyyaml`, and
-`requests`. Optional self-tracing support is provided by the
-[`Self-Tracing`](https://github.com/recursivelabsai/Self-Tracing) project.
+the Circuit Tracer thought logging system. The project targets Python 3.10+ and
+depends on `torch`, `transformers`, `trl`, `pydantic`, `jinja2`, `pyyaml`, and
+`requests`. Optional Circuit Tracer support is provided by the
+[`circuit-tracer`](https://github.com/safety-research/circuit-tracer) project.
 Public packages for that integration are not currently available, so the
 feature remains disabled unless you have been granted access to the upstream
 distribution.
@@ -14,11 +14,11 @@ distribution.
 
 - `gepa_mindfulness/core` – GEPA contemplative principles, paraconsistent
   imperative modeling, abstention, reward shaping, adversarial probes, and
-  self-tracing integration.
+  Circuit Tracer integration.
 - `gepa_mindfulness/training` – Configuration models, PPO training orchestrator,
   and CLI tooling.
-- `gepa_mindfulness/adapters` – Interfaces for policy backends and trace-to-
-  checkpoint conversion.
+- `gepa_mindfulness/adapters` – Interfaces for policy backends and Circuit
+  Tracer-to-checkpoint conversion.
 - `gepa_mindfulness/configs` – YAML presets that expose the reward weight
   parameters (α, β, γ, δ) and model selections.
 - `gepa_mindfulness/examples` – Runnable CPU and vLLM demonstrations.
@@ -38,7 +38,8 @@ files can be consumed directly or redistributed in packaged form.
    Empathy, Perspective, Agency) and aggregates them alongside three alignment
    imperatives (Reduce Suffering, Increase Prosperity, Increase Knowledge) using
    paraconsistent logic to tolerate conflicting objectives.
-2. **Self-Tracing** – Wraps the [Self-Tracing](https://github.com/recursivelabsai/Self-Tracing)
+2. **Circuit Tracing** – Wraps the
+   [Circuit Tracer](https://github.com/safety-research/circuit-tracer)
    library to capture framing, evidence, tensions, decisions, and reflections
    for every rollout. These traces produce GEPA checkpoints and honesty reward
    signals.
@@ -88,7 +89,7 @@ Git metadata locally.
    pip install torch transformers trl pydantic jinja2 pyyaml requests
    ```
 
-   If you have private access to the optional self-tracing package, install it
+   If you have private access to the optional Circuit Tracer package, install it
    after the core dependencies using the URL provided by the maintainer. If you
    do not have access, skip the step—the remainder of the project functions
    without it.
@@ -105,7 +106,7 @@ Git metadata locally.
    > source .venv/bin/activate
    > pip install --upgrade pip
    > pip install torch transformers trl pydantic jinja2 pyyaml requests
-   > # Optional: install the self-tracing package only if you have access to it
+   > # Optional: install the Circuit Tracer package only if you have access to it
    > ```
    >
    > When you are done working, run `deactivate` to exit the environment. Any

--- a/docs/NEWCOMER_GUIDE.md
+++ b/docs/NEWCOMER_GUIDE.md
@@ -6,9 +6,9 @@ This guide summarizes the current codebase so you can orient yourself quickly an
 
 | Area | Purpose |
 | ---- | ------- |
-| [`gepa_mindfulness/core/`](../gepa_mindfulness/core) | GEPA contemplative principles, paraconsistent imperatives, reward shaping, abstention, self-tracing, and adversarial probes that power the alignment logic. |
+| [`gepa_mindfulness/core/`](../gepa_mindfulness/core) | GEPA contemplative principles, paraconsistent imperatives, reward shaping, abstention, Circuit Tracer integration, and adversarial probes that power the alignment logic. |
 | [`gepa_mindfulness/training/`](../gepa_mindfulness/training) | Configuration models, PPO orchestration, CLI entry points, and reporting helpers for running alignment-focused training loops. |
-| [`gepa_mindfulness/adapters/`](../gepa_mindfulness/adapters) | Interfaces that let the training pipeline talk to Hugging Face models, vLLM endpoints, and self-tracing artifacts. |
+| [`gepa_mindfulness/adapters/`](../gepa_mindfulness/adapters) | Interfaces that let the training pipeline talk to Hugging Face models, vLLM endpoints, and Circuit Tracer artifacts. |
 | [`gepa_mindfulness/examples/`](../gepa_mindfulness/examples) | Runnable CPU and vLLM demos that show the pipeline end-to-end. |
 | [`gepa_datasets/`](../gepa_datasets) | JSONL datasets for ethical QA, OOD stress testing, anti-scheming probes, abstention calibration, and thought-trace templates. |
 | [`gepa_mindfulness/configs/`](../gepa_mindfulness/configs) | YAML presets exposing reward weights (α, β, γ, δ), model choices, and runtime parameters. |
@@ -24,7 +24,7 @@ The `core` package implements the conceptual building blocks of GEPA mindfulness
 * **Imperatives & paraconsistency** – `imperatives.py` and `paraconsistent.py` combine signals for the Reduce Suffering, Increase Prosperity, and Increase Knowledge imperatives using dialetheic conjunction to tolerate conflicting evidence.【F:gepa_mindfulness/core/imperatives.py†L1-L55】【F:gepa_mindfulness/core/paraconsistent.py†L1-L44】
 * **Abstention & honesty rewards** – `abstention.py` enforces confidence-aware abstention and computes honesty rewards driven by mindfulness and emptiness cues.【F:gepa_mindfulness/core/abstention.py†L1-L45】
 * **Reward shaping** – `rewards.py` fuses task success, GEPA scores, honesty traces, hallucination penalties, and paraconsistent truth into a single PPO scalar.【F:gepa_mindfulness/core/rewards.py†L1-L36】
-* **Self-tracing & adversarial probes** – `tracing.py` wraps the optional Self-Tracing dependency while gracefully degrading when unavailable; `adversarial.py` offers scheming-inspired OOD scenarios.【F:gepa_mindfulness/core/tracing.py†L1-L63】【F:gepa_mindfulness/core/adversarial.py†L1-L45】
+* **Circuit tracing & adversarial probes** – `tracing.py` wraps the optional Circuit Tracer dependency while gracefully degrading when unavailable; `adversarial.py` offers scheming-inspired OOD scenarios.【F:gepa_mindfulness/core/tracing.py†L1-L141】【F:gepa_mindfulness/core/adversarial.py†L1-L45】
 
 These components are re-exported via `gepa_mindfulness.core.__init__` for convenient imports across the project.【F:gepa_mindfulness/core/__init__.py†L1-L22】
 
@@ -33,7 +33,7 @@ These components are re-exported via `gepa_mindfulness.core.__init__` for conven
 The `training` package turns the alignment primitives into an executable PPO workflow:
 
 * **Configuration** – `configs.py` defines Pydantic models for reward weights, PPO hyperparameters, model selection, and adversity thresholds, plus YAML loaders for presets.【F:gepa_mindfulness/training/configs.py†L1-L47】
-* **Orchestration** – `pipeline.py` builds the tokenizer/model stack, maintains a `SelfTracingLogger`, enforces abstention, scores GEPA principles, aggregates imperatives, and updates PPO rewards each rollout.【F:gepa_mindfulness/training/pipeline.py†L1-L147】
+* **Orchestration** – `pipeline.py` builds the tokenizer/model stack, maintains a `CircuitTracerLogger`, enforces abstention, scores GEPA principles, aggregates imperatives, and updates PPO rewards each rollout.【F:gepa_mindfulness/training/pipeline.py†L1-L147】
 * **CLI tooling** – `cli.py` wires configs, datasets, and adversarial-only sweeps into a single command-line entry point for production or evaluation runs.【F:gepa_mindfulness/training/cli.py†L1-L67】
 * **Reporting** – `reporting.py` uses Jinja2 to render human-readable summaries of rollout rewards and contradictions.【F:gepa_mindfulness/training/reporting.py†L1-L40】
 

--- a/gepa_datasets/thought_trace_templates/README.md
+++ b/gepa_datasets/thought_trace_templates/README.md
@@ -1,4 +1,4 @@
 # Thought-Trace Templates
 
-Purpose: Provide Self-Tracing style event templates for an Ethical and an OOD case.
+Purpose: Provide Circuit Tracer style event templates for an Ethical and an OOD case.
 Files: `ethical_icubed.jsonl`, `ood_injection.jsonl`

--- a/gepa_mindfulness/adapters/README.md
+++ b/gepa_mindfulness/adapters/README.md
@@ -5,8 +5,8 @@ systems:
 
 - `policy_adapter.py` abstracts text generation so the same code path can
   target Hugging Face Transformers or a remote vLLM endpoint.
-- `tracing_adapter.py` converts detailed self-tracing outputs into compact GEPA
-  checkpoints for logging or reward shaping.
+- `tracing_adapter.py` converts detailed Circuit Tracer outputs into compact
+  GEPA checkpoints for logging or reward shaping.
 
 These utilities keep the core pipeline backend-agnostic and simplify
 integration with new inference engines or logging backends.

--- a/gepa_mindfulness/adapters/tracing_adapter.py
+++ b/gepa_mindfulness/adapters/tracing_adapter.py
@@ -1,4 +1,4 @@
-"""Adapters bridging policy rollouts with self-tracing artifacts."""
+"""Adapters bridging policy rollouts with Circuit Tracer artifacts."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from ..core.tracing import ThoughtTrace
 
 @dataclass
 class TraceToCheckpoint:
-    """Convert traces into GEPA checkpoint dictionaries."""
+    """Convert Circuit Tracer logs into GEPA checkpoint dictionaries."""
 
     def __call__(self, trace: ThoughtTrace) -> Dict[str, str]:
         payload: Dict[str, str] = {}

--- a/gepa_mindfulness/core/README.md
+++ b/gepa_mindfulness/core/README.md
@@ -1,7 +1,7 @@
 # Core GEPA Logic
 
 This package implements the GEPA contemplative principles, paraconsistent
-imperatives, self-tracing integration, adversarial challenge utilities, and
+imperatives, Circuit Tracer integration, adversarial challenge utilities, and
 confidence-aware abstention logic used throughout the training pipeline.
 
 Key components:
@@ -9,7 +9,7 @@ Key components:
 - `contemplative_principles.py` implements the four contemplative axes.
 - `imperatives.py` models the three alignment imperatives using paraconsistent
   aggregation.
-- `tracing.py` integrates Anthropic-style Self-Tracing.
+- `tracing.py` integrates the optional Circuit Tracer thought logging system.
 - `abstention.py` enforces the confidence-based abstention rule and honesty
   reward computation.
 - `rewards.py` shapes the PPO signal from task, GEPA, honesty, and hallucination

--- a/gepa_mindfulness/core/__init__.py
+++ b/gepa_mindfulness/core/__init__.py
@@ -6,7 +6,7 @@ from .contemplative_principles import ContemplativePrinciple, GEPAPrinciples, GE
 from .imperatives import AlignmentImperative, ImperativeEvaluator, ImperativeSignal
 from .paraconsistent import ParaconsistentTruthValue, dialetheic_and
 from .rewards import RewardSignal, RewardWeights
-from .tracing import SelfTracingLogger, ThoughtTrace, TraceEvent
+from .tracing import CircuitTracerLogger, ThoughtTrace, TraceEvent
 
 __all__ = [
     "ABSTAIN_OUTPUT",
@@ -25,7 +25,7 @@ __all__ = [
     "dialetheic_and",
     "RewardSignal",
     "RewardWeights",
-    "SelfTracingLogger",
+    "CircuitTracerLogger",
     "ThoughtTrace",
     "TraceEvent",
 ]

--- a/gepa_mindfulness/core/tracing.py
+++ b/gepa_mindfulness/core/tracing.py
@@ -1,21 +1,11 @@
-"""Integration layer for Anthropic-style self-tracing."""
+"""Integration layer for the optional Circuit Tracer thought logging system."""
 
 from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import (
-    Any,
-    Callable,
-    ContextManager,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Protocol,
-    cast,
-)
+from typing import Any, Callable, ContextManager, Iterator, List, Protocol, cast
 
 try:  # pragma: no cover - optional dependency missing in most environments
     from mindful_trace_gepa.utils.imports import optional_import
@@ -32,26 +22,46 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when package absent
 
 
 class TracerProtocol(Protocol):
-    """Minimal protocol implemented by ``self_tracing.Tracer``."""
+    """Minimal protocol implemented by ``circuit_tracer.CircuitTracer``."""
 
     def span(self, **context: Any) -> ContextManager[Any]: ...
 
     def log(self, *, stage: str, content: str, **metadata: Any) -> None: ...
 
 
-_TRACER_MODULE = optional_import("self_tracing")
-TracerFactory: Callable[[], TracerProtocol] | None
+_TRACER_MODULE = optional_import("circuit_tracer")
+
+
+def _resolve_tracer_factory(module: Any) -> Callable[..., TracerProtocol] | None:
+    """Best-effort discovery of a Circuit Tracer constructor."""
+
+    candidate_names = [
+        "CircuitTracer",
+        "Tracer",
+        "CircuitThoughtTracer",
+        "create_tracer",
+    ]
+    for name in candidate_names:
+        candidate = getattr(module, name, None)
+        if callable(candidate):
+            return candidate
+    return None
+
+
+TracerFactory: Callable[..., TracerProtocol] | None
 if _TRACER_MODULE is not None:
-    candidate = getattr(_TRACER_MODULE, "Tracer", None)
-    TracerFactory = candidate if callable(candidate) else None
+    TracerFactory = _resolve_tracer_factory(_TRACER_MODULE)
 else:  # pragma: no cover - optional dependency missing
     TracerFactory = None
 
 
-def _create_tracer() -> TracerProtocol | None:
+def _create_tracer(**factory_kwargs: Any) -> TracerProtocol | None:
     if TracerFactory is None:
         return None
-    tracer = TracerFactory()
+    try:
+        tracer = TracerFactory(**factory_kwargs)
+    except TypeError:
+        tracer = TracerFactory()  # type: ignore[misc]
     return cast(TracerProtocol, tracer)
 
 
@@ -68,7 +78,7 @@ class TraceEvent:
 
 @dataclass
 class ThoughtTrace:
-    """Container storing self-tracing events for a single rollout."""
+    """Container storing Circuit Tracer events for a single rollout."""
 
     events: list[TraceEvent] = field(default_factory=list)
 
@@ -92,11 +102,12 @@ class ThoughtTrace:
         return {event.stage: event.content for event in self.events}
 
 
-class SelfTracingLogger:
-    """Wrapper that gracefully falls back if the optional dependency is missing."""
+class CircuitTracerLogger:
+    """Wrapper that gracefully falls back when Circuit Tracer is absent."""
 
-    def __init__(self) -> None:
-        self._tracer = _create_tracer()
+    def __init__(self, **factory_kwargs: Any) -> None:
+        self._factory_kwargs = dict(factory_kwargs)
+        self._tracer = _create_tracer(**self._factory_kwargs)
         self._active_traces: List[ThoughtTrace] = []
 
     @contextlib.contextmanager
@@ -123,3 +134,8 @@ class SelfTracingLogger:
     @property
     def latest_trace(self) -> ThoughtTrace | None:
         return self._active_traces[-1] if self._active_traces else None
+
+    def refresh_backend(self) -> None:
+        """Recreate the underlying tracer instance with stored kwargs."""
+
+        self._tracer = _create_tracer(**self._factory_kwargs)

--- a/gepa_mindfulness/training/README.md
+++ b/gepa_mindfulness/training/README.md
@@ -1,12 +1,12 @@
 # Training Modules
 
 The training package wires the GEPA core logic into an end-to-end PPO training
-loop that records self-traces, enforces abstention, and performs adversarial
+loop that records Circuit Tracer logs, enforces abstention, and performs adversarial
 checks.
 
 - `configs.py` defines Pydantic models and YAML loaders for all configurable
   hyper-parameters including reward weights (α, β, γ, δ).
-- `pipeline.py` orchestrates the PPO trainer, GEPA scoring, self-tracing,
+- `pipeline.py` orchestrates the PPO trainer, GEPA scoring, Circuit Tracer
   abstention, and adversarial evaluation.
 - `cli.py` exposes a command line entry point for running training or
   adversarial-only sweeps.

--- a/gepa_mindfulness/training/pipeline.py
+++ b/gepa_mindfulness/training/pipeline.py
@@ -21,7 +21,7 @@ from ..core.contemplative_principles import (
 )
 from ..core.imperatives import AlignmentImperative, ImperativeEvaluator, ImperativeSignal
 from ..core.rewards import RewardSignal, RewardWeights
-from ..core.tracing import SelfTracingLogger
+from ..core.tracing import CircuitTracerLogger
 from .configs import TrainingConfig
 
 LOGGER = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class TrainingOrchestrator:
 
     def __init__(self, config: TrainingConfig) -> None:
         self.config = config
-        self.tracing = SelfTracingLogger()
+        self.tracing = CircuitTracerLogger()
         self.device = torch.device(config.device)
         self.tokenizer = AutoTokenizer.from_pretrained(config.model.policy_model)
         self.policy_model = AutoModelForCausalLM.from_pretrained(config.model.policy_model).to(

--- a/notebooks/ft_llama3_8b_unsloth_gepa.ipynb
+++ b/notebooks/ft_llama3_8b_unsloth_gepa.ipynb
@@ -51,7 +51,7 @@
         "",
         "import yaml",
         "",
-        "from gepa_mindfulness.core.tracing import SelfTracingLogger",
+        "from gepa_mindfulness.core.tracing import CircuitTracerLogger",
         "from gepa_mindfulness.adapters.self_tracing import format_trace_example",
         "",
         "random.seed(13)",
@@ -198,7 +198,7 @@
         "trace_path = runs_dir / 'trace.jsonl'",
         "summary_path = runs_dir / 'summary.json'",
         "",
-        "tracer = SelfTracingLogger(base_path=runs_dir)",
+        "tracer = CircuitTracerLogger(base_path=runs_dir)",
         "",
         "ABSTENTION_THRESHOLD = model_config['gepa']['abstention_threshold']",
         "ABSTENTION_TEXT = model_config['gepa']['abstention_text']",
@@ -215,7 +215,7 @@
       "source": [
         "### Supervised fine-tuning loop",
         "",
-        "For CPU smoke tests we run only a handful of optimisation steps. Replace the placeholders with the real Unsloth trainer when running on GPU. Each batch logs GEPA events via the Self-Tracing adapter."
+        "For CPU smoke tests we run only a handful of optimisation steps. Replace the placeholders with the real Unsloth trainer when running on GPU. Each batch logs GEPA events via the Circuit Tracer adapter."
       ]
     },
     {

--- a/notebooks/ft_phi3_mini_unsloth_gepa.ipynb
+++ b/notebooks/ft_phi3_mini_unsloth_gepa.ipynb
@@ -51,7 +51,7 @@
         "",
         "import yaml",
         "",
-        "from gepa_mindfulness.core.tracing import SelfTracingLogger",
+        "from gepa_mindfulness.core.tracing import CircuitTracerLogger",
         "from gepa_mindfulness.adapters.self_tracing import format_trace_example",
         "",
         "random.seed(13)",
@@ -198,7 +198,7 @@
         "trace_path = runs_dir / 'trace.jsonl'",
         "summary_path = runs_dir / 'summary.json'",
         "",
-        "tracer = SelfTracingLogger(base_path=runs_dir)",
+        "tracer = CircuitTracerLogger(base_path=runs_dir)",
         "",
         "ABSTENTION_THRESHOLD = model_config['gepa']['abstention_threshold']",
         "ABSTENTION_TEXT = model_config['gepa']['abstention_text']",
@@ -215,7 +215,7 @@
       "source": [
         "### Supervised fine-tuning loop",
         "",
-        "For CPU smoke tests we run only a handful of optimisation steps. Replace the placeholders with the real Unsloth trainer when running on GPU. Each batch logs GEPA events via the Self-Tracing adapter."
+        "For CPU smoke tests we run only a handful of optimisation steps. Replace the placeholders with the real Unsloth trainer when running on GPU. Each batch logs GEPA events via the Circuit Tracer adapter."
       ]
     },
     {

--- a/src/mindful_trace_gepa/dspy_modules/pipeline.py
+++ b/src/mindful_trace_gepa/dspy_modules/pipeline.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, MutableMapping
 
-from gepa_mindfulness.core.tracing import SelfTracingLogger, ThoughtTrace
+from gepa_mindfulness.core.tracing import CircuitTracerLogger, ThoughtTrace
 
 from ..configuration import DSPyConfig, load_dspy_config
 from .signatures import (
@@ -65,7 +65,7 @@ class GEPAChain:
         self.allow_optimizations = (
             self.config.allow_optimizations if allow_optimizations is None else allow_optimizations
         )
-        self.tracer = SelfTracingLogger()
+        self.tracer = CircuitTracerLogger()
 
     # ------------------------------------------------------------------
     # Default behaviours

--- a/tests/test_rubric_core.py
+++ b/tests/test_rubric_core.py
@@ -10,7 +10,7 @@ from gepa_mindfulness.core.paraconsistent import (
     dialetheic_and,
 )
 from gepa_mindfulness.core.rewards import RewardSignal, RewardWeights
-from gepa_mindfulness.core.tracing import SelfTracingLogger
+from gepa_mindfulness.core.tracing import CircuitTracerLogger
 
 
 def test_principle_aggregation_and_reward_signal() -> None:
@@ -60,8 +60,8 @@ def test_dialetheic_and_limits() -> None:
     assert 0.0 <= combined.truthiness <= 1.0
 
 
-def test_self_tracing_logger_records_and_validates_stages() -> None:
-    logger = SelfTracingLogger()
+def test_circuit_tracer_logger_records_and_validates_stages() -> None:
+    logger = CircuitTracerLogger()
     with logger.trace(run="unit-test") as trace:
         logger.log_event("framing", "Assess situation", principle_scores={"mindfulness": 0.9})
         logger.log_event(


### PR DESCRIPTION
## Summary
- replace the self-tracing adapter with the optional circuit-tracer module and add a refresh helper
- update training, DSPy pipelines, tests, and notebooks to use the new CircuitTracerLogger
- refresh project documentation and dataset notes to reference circuit-tracer artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6875c72e4833099e5d7c23aa431ed